### PR TITLE
Hotfix/Added errorhandling for api calls

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PUBLIC_API_URL=http://localhost:3011

--- a/src/lib/helpers/ajaxhelper.js
+++ b/src/lib/helpers/ajaxhelper.js
@@ -3,13 +3,13 @@
      * @param url
      */
 export const getData = async (url, fetchFn = fetch) => {
-    try {
-        const response = await fetchFn(url);
-        const items = await response.json();
-        return items;
-    } catch (error) {
-        return error;
+    const response = await fetchFn(url);
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}`);
     }
+
+    return await response.json();
 };
 
 /**

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,11 +1,16 @@
 import { getData } from "$lib/helpers/ajaxhelper.js";
 import { PUBLIC_API_URL } from "$env/static/public";
+import { error } from "@sveltejs/kit";
 
 /**
  * Function to load appointments
  * @returns 
  */
 export const load = async () => {
-    const events = await getData(`${PUBLIC_API_URL}/events/`);
-    return { events }
+    try {
+        const events = await getData(`${PUBLIC_API_URL}/events/`);
+        return { events };
+    } catch (err) {
+        throw error(500, 'Failed to load events');
+    }
 };


### PR DESCRIPTION
This hotfix prevents non-serializable Error objects from being returned from the event load() function.
API fetch errors are now properly thrown instead of returned, fixing SSR serialization crashes when the API is unavailable.