### PR TITLE
Feature/registered users for events

### DIFF
--- a/src/lib/components/+Event.svelte
+++ b/src/lib/components/+Event.svelte
@@ -7,18 +7,22 @@
     Users,
     Edit,
     Pen,
+    ShieldCheck
   } from "lucide-svelte";
   import { formatCardDate } from "$lib/helpers/dateTimeFormatter.js";
   import { enhance } from "$app/forms";
   import CreateUpdateModal from "./events/+CreateUpdateModal.svelte";
   import DeleteModal from "./DeleteModal.svelte";
   import { page } from "$app/stores";
-    import { toggleRegistration } from "$lib/helpers/events/toggleEvents";
+  import { toggleRegistration } from "$lib/helpers/events/toggleEvents";
 
   let { event } = $props();
   const user = $page.data?.user;
 
   const displayDate = formatCardDate(event.date || event.startAt);
+
+  // Identity logic
+  const isOrganizer = user?.id === event.organizerId;
 
   // Non-reactive state
   const spotsLeft = event.maxParticipants || 0;
@@ -55,7 +59,8 @@
 
   const handleRegisterClick = async (e) => {
     e.stopPropagation();
-    if (!user || isFull) return;
+    e.preventDefault(); 
+    if (!user || isFull || isOrganizer) return;
 
     const token = $page.data?.token;
     await toggleRegistration(event.id, token);
@@ -87,7 +92,7 @@
       </div>
     </div>
 
-    {#if user.role === 'GREEN_OFFICE_MEMBER'}
+    {#if user?.role === 'GREEN_OFFICE_MEMBER'}
     <div class="absolute bottom-3 right-3 flex flex-row gap-2 items-end">
       <button
         type="button"
@@ -138,22 +143,32 @@
     </div>
 
     <div class="pt-1">
-<div
-  class={`relative z-10 w-full flex items-center justify-center px-5 py-2 rounded-full text-base font-semibold shadow-lg transition-all duration-200 cursor-pointer
-    ${isFull ? 'bg-red-700 text-white opacity-80' 
-      : isRegistered ? 'bg-stone-700 text-white hover:bg-stone-800' 
-      : 'bg-green-600 text-white group-hover:bg-green-700 group-hover:-translate-y-0.5'}`}
-  onclick={handleRegisterClick}
->
-  {isRegistered ? "Deregister" : isFull ? "Full" : "Register Now"}
-</div>
+      {#if isOrganizer}
+        <div class="w-full flex items-center justify-center gap-2 py-2 rounded-full border border-green-200 bg-green-50/50 text-green-700 text-sm font-bold uppercase tracking-widest">
+          <ShieldCheck class="w-4 h-4" />
+          Your Event
+        </div>
+      {:else}
+        <div
+          role="button"
+          tabindex="0"
+          class={`relative z-10 w-full flex items-center justify-center px-5 py-2 rounded-full text-base font-semibold shadow-lg transition-all duration-200 cursor-pointer
+            ${isFull ? 'bg-red-700 text-white opacity-80' 
+              : isRegistered ? 'bg-stone-700 text-white hover:bg-stone-800' 
+              : 'bg-green-600 text-white group-hover:bg-green-700 group-hover:-translate-y-0.5'}`}
+          onclick={handleRegisterClick}
+          onkeydown={(e) => e.key === 'Enter' && handleRegisterClick(e)}
+        >
+          {isRegistered ? "Deregister" : isFull ? "Full" : "Register Now"}
+        </div>
+      {/if}
     </div>
   </div>
 </a>
 
 {#if isModalOpen}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-    <div class="w-full max-w-2xl p-4" onclick={(e) => e.stopPropagation()}>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onclick={closeModal}>
+    <div class="w-full max-w-2xl p-4" onclick={(e) => e.stopPropagation()} role="presentation">
       <form
         method="POST"
         action="?/update"

--- a/src/routes/(app)/events/+page.svelte
+++ b/src/routes/(app)/events/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Search, X, Calendar, Check, Plus } from "lucide-svelte";
+  import { Search, X, Calendar, Check, Plus, MapPin, Clock } from "lucide-svelte";
   import Event from "$lib/components/+Event.svelte";
   import { page } from "$app/stores";
   import { enhance } from "$app/forms";
@@ -36,7 +36,7 @@
   const events = data.events.data;
   const user = $page.data?.user;
 
-  // Reactive Logic
+  // Reactive Logic for Main Feed
   let filteredEvents = $derived(
     events.filter((event) => {
       const query = searchQuery.toLowerCase();
@@ -47,24 +47,24 @@
       const matchesCategory = filter === "All" || event.category === filter;
 
       return matchesSearch && matchesCategory;
-    }),
+    })
   );
 
-  const registeredEvents = events.filter((event) => event.isRegistered);
+  let registeredEvents = $derived(
+    events.filter((event) => 
+      user?.eventRegistrations?.some((reg) => reg.eventId === event.id)
+    )
+  );
 
   const openModal = () => (isModalOpen = true);
   const closeModal = () => (isModalOpen = false);
 </script>
 
-<div
-  class="flex flex-col space-y-6 pb-24 bg-stone-50 min-h-screen cursor-default"
->
+<div class="flex flex-col space-y-6 pb-24 bg-stone-50 min-h-screen cursor-default">
   <header class="px-6 pt-10 pb-4 bg-white shadow-sm rounded-b-3xl">
     <div class="flex justify-between items-start mb-4 h-12">
       <div>
-        <div
-          class="text-xs uppercase tracking-widest text-green-700 font-bold mb-1"
-        >
+        <div class="text-xs uppercase tracking-widest text-green-700 font-bold mb-1">
           Fruit Forest
         </div>
         <h1 class="font-serif text-4xl italic font-bold text-stone-900">
@@ -73,14 +73,14 @@
       </div>
 
       <div class="flex items-center space-x-2">
-        {#if user.role === 'GREEN_OFFICE_MEMBER'}
-        <button
-          onclick={openModal}
-          class="p-2 rounded-md bg-green-700 hover:bg-green-800 text-white transition-colors shadow-md cursor-pointer"
-          title="Create New Event"
-        >
-          <Plus class="w-5 h-5" />
-        </button>
+        {#if user?.role === 'GREEN_OFFICE_MEMBER'}
+          <button
+            onclick={openModal}
+            class="p-2 rounded-md bg-green-700 hover:bg-green-800 text-white transition-colors shadow-md cursor-pointer"
+            title="Create New Event"
+          >
+            <Plus class="w-5 h-5" />
+          </button>
         {/if}
         <div class="flex items-center bg-stone-100 rounded-lg p-2 w-48 sm:w-64">
           <Search class="w-4 h-4 text-stone-400 ml-1" />
@@ -91,10 +91,7 @@
             class="bg-transparent border-none outline-none text-sm w-full text-stone-800 px-2 cursor-text"
           />
           {#if searchQuery}
-            <button
-              class="cursor-pointer p-1"
-              onclick={() => (searchQuery = "")}
-            >
+            <button class="cursor-pointer p-1" onclick={() => (searchQuery = "")}>
               <X class="w-4 h-4 text-stone-400 hover:text-stone-600" />
             </button>
           {/if}
@@ -122,48 +119,78 @@
     </div>
   </header>
 
-  <div class="px-6">
+  {#if registeredEvents.length > 0 && !searchQuery && filter === "All"}
+    <section class="px-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="font-serif text-2xl italic font-bold text-stone-800">
+          Registered Events
+        </h2>
+        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold">
+          {registeredEvents.length} Registered
+        </span>
+      </div>
+      
+      <div class="flex overflow-x-auto space-x-4 pb-4 scrollbar-hide -mx-2 px-2">
+        {#each registeredEvents as event (event.id)}
+          <a 
+            href={`/events/${event.id}`} 
+            class="flex-shrink-0 w-72 bg-white rounded-2xl shadow-sm border border-stone-200 p-4 hover:shadow-md transition-shadow group"
+          >
+            <div class="flex gap-4">
+              <div class="w-16 h-16 rounded-xl overflow-hidden bg-stone-100 shrink-0">
+                <img 
+                  src={event.thumbnail || "https://picsum.photos/200"} 
+                  alt={event.title} 
+                  class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
+                />
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center text-green-700 gap-1 mb-1">
+                  <Check class="w-3 h-3" />
+                  <span class="text-[10px] font-black uppercase tracking-widest">Enrolled</span>
+                </div>
+                <h3 class="font-bold text-stone-900 text-sm truncate">{event.title}</h3>
+                <div class="flex flex-col gap-1 mt-2 text-stone-500">
+                  <div class="flex items-center gap-1.5 text-[11px]">
+                    <Calendar class="w-3 h-3" /> <span>{event.date || event.startAt}</span>
+                  </div>
+                  {#if event.location}
+                    <div class="flex items-center gap-1.5 text-[11px]">
+                      <MapPin class="w-3 h-3" /> <span class="truncate">{event.location}</span>
+                    </div>
+                  {/if}
+                </div>
+              </div>
+            </div>
+          </a>
+        {/each}
+      </div>
+    </section>
+    <hr class="mx-6 border-stone-200" />
+  {/if}
+
+  <main class="px-6">
+    <div class="flex items-center justify-between mb-4">
+        <h2 class="font-serif text-2xl italic font-bold text-stone-800">
+            {filter === "All" ? "Explore Events" : `${filter} Events`}
+        </h2>
+    </div>
+
     {#if filteredEvents.length === 0}
-      <div class="text-center py-10 text-stone-400">
-        <p>No events found matching "{searchQuery}" in {filter}.</p>
+      <div class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300">
+        <p class="text-stone-400">No events found matching "{searchQuery}" in {filter}.</p>
       </div>
     {:else}
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {#each filteredEvents as event (event.id)}
           <Event {event} />
         {/each}
       </div>
     {/if}
-  </div>
-
-  {#if registeredEvents.length > 0 && !searchQuery}
-    <div class="px-6 mt-10">
-      <h2 class="font-serif text-2xl italic font-bold text-stone-800 mb-4">
-        My Registrations ({registeredEvents.length})
-      </h2>
-      <div class="space-y-4">
-        {#each registeredEvents as event (event.id)}
-          <div
-            class="flex items-center p-3 bg-green-50 rounded-xl shadow-sm border border-green-100"
-          >
-            <div class="text-xl mr-3">{event.image?.substring(0, 1)}</div>
-            <div class="flex-1">
-              <p class="text-sm font-bold text-green-800">{event.title}</p>
-              <p class="text-xs text-green-600 flex items-center space-x-1">
-                <Calendar class="w-3 h-3" /> <span>{event.date}</span>
-              </p>
-            </div>
-            <Check class="w-5 h-5 text-green-700" />
-          </div>
-        {/each}
-      </div>
-    </div>
-  {/if}
+  </main>
 
   {#if isModalOpen}
-    <div
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm"
-    >
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm">
       <form
         method="POST"
         action="?/create"

--- a/src/routes/(app)/events/[id]/+page.svelte
+++ b/src/routes/(app)/events/[id]/+page.svelte
@@ -225,12 +225,14 @@
           <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
             <Users class="w-6 h-6 text-green-600" /> Capacity
           </h2>
+          {#if user.role === "GREEN_OFFICE_MEMBER"}
           <button
             onclick={() => (showParticipants = true)}
             class="text-xs font-bold uppercase py-1 px-3 rounded-lg bg-stone-100 text-stone-600 hover:bg-green-100 hover:text-green-700 transition flex items-center gap-1 cursor-pointer"
           >
             <Eye class="w-3 h-3" /> View List
           </button>
+          {/if}
         </div>
 
         <div class={`p-4 rounded-xl border-2 ${participantStatus.color}`}>

--- a/src/routes/(app)/events/[id]/+page.svelte
+++ b/src/routes/(app)/events/[id]/+page.svelte
@@ -11,7 +11,6 @@
     Star,
     Mail,
     Eye,
-    EyeOff,
     X,
   } from "lucide-svelte";
 
@@ -26,6 +25,9 @@
   let event = data.event.event;
 
   const user = $page.data?.user;
+
+  // Check if current user is the organizer
+  const isOrganizer = user?.id === event.organizerId;
 
   const displayDate = formatFullDate(event.date || event.startAt, "Date TBD");
   const displayStartTime = formatTime(event.startAt, "Time TBD");
@@ -61,7 +63,8 @@
   let isFull = currentParticipants >= event.maxParticipants;
 
   const handleToggleRegistration = async () => {
-    if (!user || isFull) return;
+    // Prevent action if not logged in, if full, or if the user is the organizer
+    if (!user || isFull || isOrganizer) return;
     const token = $page.data?.token;
     await toggleRegistration(event.id, token);
 
@@ -153,9 +156,7 @@
               </p>
             </div>
           </div>
-          <div
-            class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl"
-          >
+          <div class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl">
             <MapPin class="w-5 h-5 text-green-600 shrink-0" />
             <div>
               <span class="text-xs font-semibold uppercase text-stone-500"
@@ -166,9 +167,7 @@
               </p>
             </div>
           </div>
-          <div
-            class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl"
-          >
+          <div class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl">
             <Mail class="w-5 h-5 text-green-600 shrink-0" />
             <div>
               <span class="text-xs font-semibold uppercase text-stone-500"
@@ -258,24 +257,26 @@
         {/if}
 
         <div class="pt-4 border-t border-stone-100">
-          <button
-            onclick={handleToggleRegistration}
-            class="w-full py-3 rounded-xl text-white font-extrabold text-lg shadow-xl transition flex items-center justify-center
-            {isFull && !isRegistered
-              ? 'bg-red-700 cursor-not-allowed shadow-none'
-              : isRegistered
-                ? 'bg-stone-700 hover:bg-stone-800'
-                : 'bg-green-600 hover:bg-green-700 shadow-green-300/60'}"
-            disabled={isFull && !isRegistered}
-          >
-            {#if isRegistered}
-              Deregister
-            {:else if isFull}
-              Full
-            {:else}
-              Register Now
-            {/if}
-          </button>
+          {#if !isOrganizer}
+            <button
+              onclick={handleToggleRegistration}
+              class="w-full py-3 rounded-xl text-white font-extrabold text-lg shadow-xl transition flex items-center justify-center gap-2
+      {isFull && !isRegistered
+                ? 'bg-red-700 cursor-not-allowed shadow-none'
+                : isRegistered
+                  ? 'bg-stone-700 hover:bg-stone-800'
+                  : 'bg-green-600 hover:bg-green-700 shadow-green-300/60'}"
+              disabled={isFull && !isRegistered}
+            >
+              {#if isRegistered}
+                Deregister
+              {:else if isFull}
+                Full
+              {:else}
+                Register Now
+              {/if}
+            </button>
+          {/if}
         </div>
       </div>
     </div>
@@ -293,23 +294,28 @@
       role="dialog"
       onclick={(e) => e.stopPropagation()}
     >
-      <header class="p-6 border-b border-stone-100 flex items-center justify-between">
+      <header
+        class="p-6 border-b border-stone-100 flex items-center justify-between"
+      >
         <h3 class="text-xl font-bold text-stone-800 flex items-center gap-2">
           <Users class="w-5 h-5 text-green-600" /> Attendees
         </h3>
-        <button 
+        <button
           onclick={() => (showParticipants = false)}
           class="p-2 hover:bg-stone-100 rounded-full transition-colors text-stone-400 hover:text-stone-600"
         >
           <X class="w-5 h-5" />
         </button>
       </header>
-      
+
       <div class="max-h-[60vh] overflow-y-auto p-2">
         <table class="w-full text-left text-sm">
           <thead class="bg-stone-50 border-b border-stone-200">
             <tr>
-              <th class="px-6 py-3 font-semibold text-stone-600 uppercase tracking-wider">User Details</th>
+              <th
+                class="px-6 py-3 font-semibold text-stone-600 uppercase tracking-wider"
+                >User Details</th
+              >
             </tr>
           </thead>
           <tbody class="divide-y divide-stone-100">
@@ -338,10 +344,10 @@
           </tbody>
         </table>
       </div>
-      
+
       <footer class="p-4 bg-stone-50 border-t border-stone-100 text-center">
         <p class="text-xs text-stone-400 font-medium uppercase tracking-widest">
-            {currentParticipants} / {event.maxParticipants || "∞"} Slots Filled
+          {currentParticipants} / {event.maxParticipants || "∞"} Slots Filled
         </p>
       </footer>
     </div>

--- a/src/routes/(app)/events/[id]/+page.svelte
+++ b/src/routes/(app)/events/[id]/+page.svelte
@@ -9,6 +9,10 @@
     Users,
     TrendingUp,
     Star,
+    Mail,
+    Eye,
+    EyeOff,
+    X,
   } from "lucide-svelte";
 
   import {
@@ -20,6 +24,7 @@
 
   let { data } = $props();
   let event = data.event.event;
+
   const user = $page.data?.user;
 
   const displayDate = formatFullDate(event.date || event.startAt, "Date TBD");
@@ -30,6 +35,9 @@
   let currentParticipants = event.currentParticipants;
   let isRegistered =
     user?.eventRegistrations?.some((r) => r.eventId === event.id) ?? false;
+
+  // State for showing the participant modal
+  let showParticipants = $state(false);
 
   const getParticipantStatus = () => {
     if (currentParticipants >= event.maxParticipants) {
@@ -146,7 +154,7 @@
             </div>
           </div>
           <div
-            class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl col-span-full"
+            class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl"
           >
             <MapPin class="w-5 h-5 text-green-600 shrink-0" />
             <div>
@@ -155,6 +163,24 @@
               >
               <p class="font-medium text-stone-800">
                 {event.location || "Online / TBD"}
+              </p>
+            </div>
+          </div>
+          <div
+            class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl"
+          >
+            <Mail class="w-5 h-5 text-green-600 shrink-0" />
+            <div>
+              <span class="text-xs font-semibold uppercase text-stone-500"
+                >Organizer</span
+              >
+              <p class="font-medium">
+                <a
+                  href={`mailto:${event.organizer.email}`}
+                  class="text-green-700 hover:text-green-800 hover:underline break-all"
+                >
+                  {event.organizer.email}
+                </a>
               </p>
             </div>
           </div>
@@ -196,9 +222,18 @@
       <div
         class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5"
       >
-        <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
-          <Users class="w-6 h-6 text-green-600" /> Capacity
-        </h2>
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
+            <Users class="w-6 h-6 text-green-600" /> Capacity
+          </h2>
+          <button
+            onclick={() => (showParticipants = true)}
+            class="text-xs font-bold uppercase py-1 px-3 rounded-lg bg-stone-100 text-stone-600 hover:bg-green-100 hover:text-green-700 transition flex items-center gap-1 cursor-pointer"
+          >
+            <Eye class="w-3 h-3" /> View List
+          </button>
+        </div>
+
         <div class={`p-4 rounded-xl border-2 ${participantStatus.color}`}>
           <p class="text-sm font-semibold uppercase">
             {participantStatus.text}
@@ -246,3 +281,69 @@
     </div>
   </div>
 </div>
+
+{#if showParticipants}
+  <div
+    class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-stone-900/60 backdrop-blur-sm animate-in fade-in duration-200"
+    role="presentation"
+    onclick={() => (showParticipants = false)}
+  >
+    <div
+      class="bg-white w-full max-w-md rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200"
+      role="dialog"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <header class="p-6 border-b border-stone-100 flex items-center justify-between">
+        <h3 class="text-xl font-bold text-stone-800 flex items-center gap-2">
+          <Users class="w-5 h-5 text-green-600" /> Attendees
+        </h3>
+        <button 
+          onclick={() => (showParticipants = false)}
+          class="p-2 hover:bg-stone-100 rounded-full transition-colors text-stone-400 hover:text-stone-600"
+        >
+          <X class="w-5 h-5" />
+        </button>
+      </header>
+      
+      <div class="max-h-[60vh] overflow-y-auto p-2">
+        <table class="w-full text-left text-sm">
+          <thead class="bg-stone-50 border-b border-stone-200">
+            <tr>
+              <th class="px-6 py-3 font-semibold text-stone-600 uppercase tracking-wider">User Details</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-stone-100">
+            {#if event.registrations && event.registrations.length > 0}
+              {#each event.registrations as registration}
+                <tr class="hover:bg-stone-50 transition-colors">
+                  <td class="px-6 py-4 text-stone-700">
+                    <div class="flex flex-col">
+                      <span class="font-bold text-stone-900"
+                        >{registration.user?.userName || "Anonymous"}</span
+                      >
+                      <span class="text-xs text-stone-500 italic break-all"
+                        >{registration.user?.email || ""}</span
+                      >
+                    </div>
+                  </td>
+                </tr>
+              {/each}
+            {:else}
+              <tr>
+                <td class="px-6 py-12 text-center text-stone-400 italic">
+                  No participants registered yet.
+                </td>
+              </tr>
+            {/if}
+          </tbody>
+        </table>
+      </div>
+      
+      <footer class="p-4 bg-stone-50 border-t border-stone-100 text-center">
+        <p class="text-xs text-stone-400 font-medium uppercase tracking-widest">
+            {currentParticipants} / {event.maxParticipants || "∞"} Slots Filled
+        </p>
+      </footer>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
Disabled Self-Registration: Prevented organizers from registering for their own events on both the Event Detail page and Event Cards.

Contextual UI: * Hidden the registration button for organizers.

Added a "Your Event" / "Organizer" indicator badge to clarify ownership.

Added event organizer email to every event details page.

Updated logic to verify organizerId against the current userId before allowing registration actions.

Added attendee list to see for Green Office Members.

Only made green office members be able to view the attendee list for events.

Added your registrations section for all the events you have registered at.

<img width="1059" height="763" alt="image" src="https://github.com/user-attachments/assets/6d4233d7-8ac6-4162-b118-d9d86fe0d22b" />
<img width="1069" height="654" alt="image" src="https://github.com/user-attachments/assets/58b829b1-1f41-455b-a812-b1d86324804f" />
<img width="1039" height="864" alt="image" src="https://github.com/user-attachments/assets/4f74d5b5-f4ce-40bf-85c3-9919e9d2956e" />
