### PR TITLE
Frontend – Plant pages, homepage map & care interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -407,18 +407,17 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.49.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.0.tgz",
-			"integrity": "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA==",
+			"version": "2.50.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.0.tgz",
+			"integrity": "sha512-Hj8sR8O27p2zshFEIJzsvfhLzxga/hWw6tRLnBjMYw70m1aS9BSYCqAUtzDBjRREtX1EvLMYgaC0mYE3Hz4KWA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.3.2",
+				"devalue": "^5.6.2",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -437,10 +436,14 @@
 				"@opentelemetry/api": "^1.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"typescript": "^5.3.3",
 				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
+					"optional": true
+				},
+				"typescript": {
 					"optional": true
 				}
 			}
@@ -1157,11 +1160,10 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
-			"integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
-			"dev": true,
-			"license": "MIT"
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+			"integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+			"dev": true
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",

--- a/src/lib/components/+Event.svelte
+++ b/src/lib/components/+Event.svelte
@@ -1,7 +1,6 @@
 <script>
   import {
     Trophy,
-    Leaf,
     Calendar,
     Sparkles,
     Users,
@@ -14,7 +13,7 @@
   import DeleteModal from './DeleteModal.svelte';
   import { page } from '$app/stores';
   import { toggleRegistration } from '$lib/helpers/events/toggleEvents';
-  import { writable } from "svelte/store";
+  import { writable } from 'svelte/store';
 
   const { event } = $props();
   const user = $page.data?.user;
@@ -104,7 +103,7 @@
       </div>
     </div>
 
-    {#if user?.role === "GREEN_OFFICE_MEMBER"}
+    {#if user?.role === 'GREEN_OFFICE_MEMBER'}
       <div class="absolute bottom-3 right-3 flex flex-row gap-2 items-end">
         <button
           type="button"
@@ -168,7 +167,7 @@
 
       {#if event.maxParticipants}
         <div
-          class={`flex items-center gap-1 rounded-full px-3 py-0.5 text-xs font-bold shrink-0 ${isFull ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"}`}
+          class={`flex items-center gap-1 rounded-full px-3 py-0.5 text-xs font-bold shrink-0 ${isFull ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'}`}
         >
           <Users class="w-3 h-3" />
           <span>{isFull ? 'Full' : `${spotsLeft} Spots`}</span>
@@ -191,13 +190,13 @@
           class={`relative z-10 w-full flex items-center justify-center px-5 py-2 rounded-full text-base font-semibold shadow-lg transition-all duration-200 cursor-pointer
             ${
               isFull
-                ? "bg-red-700 text-white opacity-80"
+                ? 'bg-red-700 text-white opacity-80'
                 : isRegistered
-                  ? "bg-stone-700 text-white hover:bg-stone-800"
-                  : "bg-green-600 text-white group-hover:bg-green-700 group-hover:-translate-y-0.5"
+                  ? 'bg-stone-700 text-white hover:bg-stone-800'
+                  : 'bg-green-600 text-white group-hover:bg-green-700 group-hover:-translate-y-0.5'
             }`}
           onclick={handleRegisterClick}
-          onkeydown={(e) => e.key === "Enter" && handleRegisterClick(e)}
+          onkeydown={(e) => e.key === 'Enter' && handleRegisterClick(e)}
         >
           {isRegistered ? 'Deregister' : isFull ? 'Full' : 'Register Now'}
         </div>

--- a/src/lib/components/+MapPlantItem.svelte
+++ b/src/lib/components/+MapPlantItem.svelte
@@ -56,6 +56,7 @@
   };
 
   const statusClass = statusColors[status] ?? "bg-green-500";
+</script>
   
 <a
   href={`/plants/${plant.id}`}

--- a/src/lib/components/+MapPlantItem.svelte
+++ b/src/lib/components/+MapPlantItem.svelte
@@ -1,34 +1,84 @@
 <script>
   let { plant = {} } = $props();
+
+  const getLatestPlanted = (p) => {
+    const arr = p?.plantedPlants;
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+
+    return [...arr].sort((a, b) => {
+      const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+      if (aTime !== bTime) return bTime - aTime;
+      return (b?.id ?? 0) - (a?.id ?? 0);
+    })[0];
+  };
+
+  const toCss = (v) => {
+    if (v === null || v === undefined || v === "") return null;
+    if (typeof v === "string") return v;
+    if (typeof v === "number") return `${v}%`; 
+    return null;
+  };
+
+  const latest = getLatestPlanted(plant);
+  const top = toCss(latest?.mapY) ?? plant?.mapPosition?.top ?? "50%";
+  const left = toCss(latest?.mapX) ?? plant?.mapPosition?.left ?? "50%";
+
   
-  // --- Helpers ---
+  const img = plant?.image;
+  const looksLikeUrl = typeof img === "string" && img.startsWith("http");
+  const markerText = looksLikeUrl
+    ? (plant?.name?.[0] ?? "P").toUpperCase()
+    : (img ?? (plant?.name?.[0] ?? "P").toUpperCase());
+
+  
+  const toLevel = (v) => {
+    const n = Number(v);
+    return n === 0 || n === 1 || n === 2 ? n : 0;
+  };
+
+  const getStatus = (p) => {
+    const latest = p?.plantedPlants?.[0];
+    const water = toLevel(latest?.waterLevel ?? 0);
+    const sun = toLevel(latest?.sunlightLevel ?? 0);
+
+    if (water === 2 || sun === 2) return "critical";
+    if (water === 1 || sun === 1) return "warning";
+    return "healthy";
+  };
+
+  const status = plant?.status ?? getStatus(plant);
+
   const statusColors = {
     critical: "bg-red-500",
     warning: "bg-amber-400",
-    healthy: "bg-green-500",
+    healthy: "bg-green-500"
   };
 
-  const statusBorders = {
-    critical: "border-red-400",
-    warning: "border-amber-300",
-    healthy: "border-stone-200",
-  };
+  const statusClass = statusColors[status] ?? "bg-green-500";
 </script>
 
-<button
-  class="absolute"
-  style="top: {plant.mapPosition.top}; left: {plant.mapPosition.left};"
+<a
+  href={`/plants/${plant.id}`}
+  class="absolute group z-20"
+  style={`top:${top}; left:${left}; transform: translate(-50%, -50%);`}
+  aria-label={`Open plant ${plant.name ?? ''}`}
 >
   <div
-    class="w-8 h-8 md:w-10 md:h-10 rounded-full border-2 border-white shadow-lg flex items-center justify-center text-sm md:text-lg text-white {statusColors[
-      plant.status
-    ]}"
+    class={`w-8 h-8 md:w-10 md:h-10 rounded-full border-2 border-white shadow-lg
+            flex items-center justify-center text-sm md:text-lg text-white
+            ${statusClass}`}
   >
-    {plant.image}
+    {markerText}
   </div>
+
   <div
-    class="absolute top-10 md:top-12 left-1/2 transform -translate-x-1/2 bg-black/80 text-white text-[10px] md:text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition whitespace-nowrap z-20 pointer-events-none"
+    class="absolute top-10 md:top-12 left-1/2 -translate-x-1/2
+           bg-black/80 text-white text-[10px] md:text-xs px-2 py-1 rounded
+           opacity-0 group-hover:opacity-100 transition whitespace-nowrap
+           z-30 pointer-events-none"
   >
     {plant.name}
   </div>
-</button>
+</a>
+

--- a/src/lib/components/+MapPlantItem.svelte
+++ b/src/lib/components/+MapPlantItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  let { plant = {} } = $props();
+  const { plant = {} } = $props();
 
   const getLatestPlanted = (p) => {
     const arr = p?.plantedPlants;
@@ -14,22 +14,22 @@
   };
 
   const toCss = (v) => {
-    if (v === null || v === undefined || v === "") return null;
-    if (typeof v === "string") return v;
-    if (typeof v === "number") return `${v}%`; 
+    if (v === null || v === undefined || v === '') return null;
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number') return `${v}%`; 
     return null;
   };
 
   const latest = getLatestPlanted(plant);
-  const top = toCss(latest?.mapY) ?? plant?.mapPosition?.top ?? "50%";
-  const left = toCss(latest?.mapX) ?? plant?.mapPosition?.left ?? "50%";
+  const top = toCss(latest?.mapY) ?? plant?.mapPosition?.top ?? '50%';
+  const left = toCss(latest?.mapX) ?? plant?.mapPosition?.left ?? '50%';
 
   
   const img = plant?.image;
-  const looksLikeUrl = typeof img === "string" && img.startsWith("http");
+  const looksLikeUrl = typeof img === 'string' && img.startsWith('http');
   const markerText = looksLikeUrl
-    ? (plant?.name?.[0] ?? "P").toUpperCase()
-    : (img ?? (plant?.name?.[0] ?? "P").toUpperCase());
+    ? (plant?.name?.[0] ?? 'P').toUpperCase()
+    : (img ?? (plant?.name?.[0] ?? 'P').toUpperCase());
 
   const toLevel = (v) => {
     const n = Number(v);
@@ -41,21 +41,21 @@
     const water = toLevel(latest?.waterLevel ?? 0);
     const sun = toLevel(latest?.sunlightLevel ?? 0);
 
-    if (water === 2 || sun === 2) return "critical";
-    if (water === 1 || sun === 1) return "warning";
-    return "healthy";
+    if (water === 2 || sun === 2) return 'critical';
+    if (water === 1 || sun === 1) return 'warning';
+    return 'healthy';
   };
 
   const status = plant?.status ?? getStatus(plant);
 
   const statusColors = {
 
-    critical: "bg-red-500",
-    warning: "bg-amber-400",
-    healthy: "bg-green-500"
+    critical: 'bg-red-500',
+    warning: 'bg-amber-400',
+    healthy: 'bg-green-500'
   };
 
-  const statusClass = statusColors[status] ?? "bg-green-500";
+  const statusClass = statusColors[status] ?? 'bg-green-500';
 </script>
   
 <a

--- a/src/lib/components/+Plant.svelte
+++ b/src/lib/components/+Plant.svelte
@@ -1,30 +1,89 @@
 <script lang="ts">
   let { plant = {} } = $props();
 
-  // --- Helpers ---
-  const statusColors = {
-    critical: "bg-red-500",
-    warning: "bg-amber-400",
-    healthy: "bg-green-500",
+  type Status = "critical" | "warning" | "healthy";
+
+  const toLevel = (v: unknown) => {
+    const n = Number(v);
+    return n === 0 || n === 1 || n === 2 ? n : 0;
   };
 
-  const statusBorders = {
-    critical: "border-3 border-red-400",
-    warning: "border-3 border-amber-300",
-    healthy: "border-none",
+  const getStatus = (p: any): Status => {
+    const latest = p?.plantedPlants?.[0];
+    const water = toLevel(latest?.waterLevel ?? 0);
+    const sun = toLevel(latest?.sunlightLevel ?? 0);
+
+    if (water === 2 || sun === 2) return "critical";
+    if (water === 1 || sun === 1) return "warning";
+    return "healthy";
   };
+
+  const statusRing: Record<Status, string> = {
+    critical: "ring-2 ring-red-300 border-red-200",
+    warning: "ring-2 ring-amber-200 border-amber-200",
+    healthy: "ring-1 ring-green-100 border-stone-200"
+  };
+
+  const badgeClasses: Record<Status, string> = {
+    critical: "bg-red-100 text-red-800 ring-1 ring-red-200",
+    warning: "bg-amber-100 text-amber-800 ring-1 ring-amber-200",
+    healthy: "bg-green-100 text-green-800 ring-1 ring-green-200"
+  };
+
+  const statusText: Record<Status, string> = {
+    critical: "Critical",
+    warning: "Needs care",
+    healthy: "Healthy"
+  };
+
+  // Svelte 5 reactive derived values
+  const status = $derived((plant?.status as Status) ?? getStatus(plant));
+  const subtitle = $derived(
+    plant?.statusDetails ??
+      plant?.scientificName ??
+      `Status: ${statusText[status]}`
+  );
+
+  const image = $derived(plant?.image || "https://picsum.photos/600/400");
+  const typeName = $derived(plant?.plantType?.name ?? "");
 </script>
 
-<button
-  class="w-full bg-white rounded-full md:rounded-xl px-4 py-2 md:p-3 flex items-center space-x-3 shadow-sm cursor-pointer hover:shadow-md active:scale-95 transition {statusBorders[plant.status]}"
+<a
+  href={`/plants/${plant.id}`}
+  class="group bg-white rounded-2xl shadow-sm hover:shadow-md transition-shadow overflow-hidden block border {statusRing[status]}"
 >
-  <div
-    class="w-5 h-5 md:w-8 md:h-8 rounded-full flex items-center justify-center text-sm md:text-base text-white {statusColors[plant.status]} shrink-0 border-2 md:border-4"
-  >
-    {plant.image}
+  <!-- image -->
+  <div class="relative w-full h-44 bg-stone-100 overflow-hidden">
+    <img
+      src={image}
+      alt={plant?.name ?? "Plant"}
+      class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+    />
+
+    <!-- status badge -->
+    <span
+      class={`absolute top-3 left-3 text-[10px] font-black uppercase tracking-widest px-2.5 py-1 rounded-full ${badgeClasses[status]}`}
+    >
+      {statusText[status]}
+    </span>
   </div>
-  <div class="text-left">
-    <span class="block text-xs md:text-sm font-bold text-stone-800">{plant.name}</span>
-    <span class="text-[10px] md:text-xs text-stone-500 line-clamp-1">{plant.statusDetails}</span>
+
+  <!-- content -->
+  <div class="p-4">
+    {#if typeName}
+      <div class="text-[10px] font-black uppercase tracking-widest text-green-700 mb-1">
+        {typeName}
+      </div>
+    {/if}
+
+    <h3 class="font-bold text-stone-900 text-base truncate">
+      {plant?.name ?? "Plant"}
+    </h3>
+
+    {#if subtitle}
+      <p class="text-[12px] text-stone-500 truncate italic mt-1">
+        {subtitle}
+      </p>
+    {/if}
   </div>
-</button>
+</a>

--- a/src/lib/components/+Plant.svelte
+++ b/src/lib/components/+Plant.svelte
@@ -1,8 +1,8 @@
-<script lang="ts">
+<script lang='ts'>
   const { plant = {} } = $props();
 
 
-  type Status = "critical" | "warning" | "healthy";
+  type Status = 'critical' | 'warning' | 'healthy';
 
   const toLevel = (v: unknown) => {
     const n = Number(v);
@@ -14,27 +14,27 @@
     const water = toLevel(latest?.waterLevel ?? 0);
     const sun = toLevel(latest?.sunlightLevel ?? 0);
 
-    if (water === 2 || sun === 2) return "critical";
-    if (water === 1 || sun === 1) return "warning";
-    return "healthy";
+    if (water === 2 || sun === 2) return 'critical';
+    if (water === 1 || sun === 1) return 'warning';
+    return 'healthy';
   };
 
   const statusRing: Record<Status, string> = {
-    critical: "ring-2 ring-red-300 border-red-200",
-    warning: "ring-2 ring-amber-200 border-amber-200",
-    healthy: "ring-1 ring-green-100 border-stone-200"
+    critical: 'ring-2 ring-red-300 border-red-200',
+    warning: 'ring-2 ring-amber-200 border-amber-200',
+    healthy: 'ring-1 ring-green-100 border-stone-200'
   };
 
   const badgeClasses: Record<Status, string> = {
-    critical: "bg-red-100 text-red-800 ring-1 ring-red-200",
-    warning: "bg-amber-100 text-amber-800 ring-1 ring-amber-200",
-    healthy: "bg-green-100 text-green-800 ring-1 ring-green-200"
+    critical: 'bg-red-100 text-red-800 ring-1 ring-red-200',
+    warning: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200',
+    healthy: 'bg-green-100 text-green-800 ring-1 ring-green-200'
   };
 
   const statusText: Record<Status, string> = {
-    critical: "Critical",
-    warning: "Needs care",
-    healthy: "Healthy"
+    critical: 'Critical',
+    warning: 'Needs care',
+    healthy: 'Healthy'
   };
 
   // Svelte 5 reactive derived values
@@ -45,20 +45,20 @@
       `Status: ${statusText[status]}`
   );
 
-  const image = $derived(plant?.image || "https://picsum.photos/600/400");
-  const typeName = $derived(plant?.plantType?.name ?? "");
+  const image = $derived(plant?.image || 'https://picsum.photos/600/400');
+  const typeName = $derived(plant?.plantType?.name ?? '');
 </script>
 
 <a
   href={`/plants/${plant.id}`}
-  class="group bg-white rounded-2xl shadow-sm hover:shadow-md transition-shadow overflow-hidden block border {statusRing[status]}"
+  class='group bg-white rounded-2xl shadow-sm hover:shadow-md transition-shadow overflow-hidden block border {statusRing[status]}'
 >
   <!-- image -->
-  <div class="relative w-full h-44 bg-stone-100 overflow-hidden">
+  <div class='relative w-full h-44 bg-stone-100 overflow-hidden'>
     <img
       src={image}
-      alt={plant?.name ?? "Plant"}
-      class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+      alt={plant?.name ?? 'Plant'}
+      class='w-full h-full object-cover group-hover:scale-105 transition-transform duration-300'
     />
 
     <!-- status badge -->
@@ -70,19 +70,19 @@
   </div>
 
   <!-- content -->
-  <div class="p-4">
+  <div class='p-4'>
     {#if typeName}
-      <div class="text-[10px] font-black uppercase tracking-widest text-green-700 mb-1">
+      <div class='text-[10px] font-black uppercase tracking-widest text-green-700 mb-1'>
         {typeName}
       </div>
     {/if}
 
-    <h3 class="font-bold text-stone-900 text-base truncate">
-      {plant?.name ?? "Plant"}
+    <h3 class='font-bold text-stone-900 text-base truncate'>
+      {plant?.name ?? 'Plant'}
     </h3>
 
     {#if subtitle}
-      <p class="text-[12px] text-stone-500 truncate italic mt-1">
+      <p class='text-[12px] text-stone-500 truncate italic mt-1'>
         {subtitle}
       </p>
     {/if}

--- a/src/lib/components/events/+CreateUpdateModal.svelte
+++ b/src/lib/components/events/+CreateUpdateModal.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { page } from "$app/stores";
+  import { page } from '$app/stores';
   import {
     formatForDateInput,
     formatForTimeInput,
@@ -21,7 +21,7 @@
     date: formData.date ? formatForDateInput(formData.date) : '',
     startAt: formData.startAt ? formatForTimeInput(formData.startAt) : '',
     endAt: formData.endAt ? formatForTimeInput(formData.endAt) : '',
-    labelId: formData.labelId ? formData.labelId : "",
+    labelId: formData.labelId ? formData.labelId : '',
   });
 
   const eventLabels = $page.data.eventLabels.data;
@@ -62,7 +62,7 @@
       class="sticky top-0 bg-white p-6 border-b border-gray-100 flex items-center justify-between z-10 shrink-0"
     >
       <h2 id="modal-title" class="text-3xl font-extrabold text-gray-800">
-        {action === "update" ? "Edit Event" : "New Event Details"}
+        {action === 'update' ? 'Edit Event' : 'New Event Details'}
       </h2>
       <button
         type="button"
@@ -300,7 +300,7 @@
         type="submit"
         class="w-full py-4 rounded-xl text-white font-extrabold text-xl bg-green-600 hover:bg-green-700 shadow-xl cursor-pointer transition-all active:scale-[0.98]"
       >
-        {action === "update" ? "Save Changes" : "Create Event"}
+        {action === 'update' ? 'Save Changes' : 'Create Event'}
       </button>
     </div>
   </div>

--- a/src/lib/components/plants/+CreateUpdateModal.svelte
+++ b/src/lib/components/plants/+CreateUpdateModal.svelte
@@ -1,14 +1,14 @@
 <script>
-  import { X, Leaf, Image, Tag, Info } from "lucide-svelte";
+  import { X, Leaf, Image, Tag, Info } from 'lucide-svelte';
 
-  let { closeModal, formData, action = "create", plantId = null } = $props();
+  const { closeModal, formData, action = 'create', plantId = null } = $props();
 
-  let localData = $derived({
+  const localData = $derived({
     ...formData
   });
 
   const handleBackdropClick = (e) => {
-    if (e.target.id === "modal-backdrop") closeModal();
+    if (e.target.id === 'modal-backdrop') closeModal();
   };
 
   const handleModalContentClick = (e) => {
@@ -22,7 +22,7 @@
   role="presentation"
   onclick={handleBackdropClick}
   onkeydown={(e) => {
-    if (e.key === "Escape") closeModal();
+    if (e.key === 'Escape') closeModal();
   }}
 >
   <div
@@ -40,7 +40,7 @@
 
     <header class="sticky top-0 bg-white p-6 border-b border-gray-100 flex items-center justify-between z-10 shrink-0">
       <h2 id="modal-title" class="text-3xl font-extrabold text-gray-800">
-        {action === "update" ? "Edit Plant" : "New Plant Details"}
+        {action === 'update' ? 'Edit Plant' : 'New Plant Details'}
       </h2>
 
       <button
@@ -153,7 +153,7 @@
         type="submit"
         class="w-full py-4 rounded-xl text-white font-extrabold text-xl bg-green-600 hover:bg-green-700 shadow-xl cursor-pointer transition-all active:scale-[0.98]"
       >
-        {action === "update" ? "Save Changes" : "Create Plant"}
+        {action === 'update' ? 'Save Changes' : 'Create Plant'}
       </button>
     </div>
   </div>

--- a/src/lib/components/plants/+CreateUpdateModal.svelte
+++ b/src/lib/components/plants/+CreateUpdateModal.svelte
@@ -1,0 +1,160 @@
+<script>
+  import { X, Leaf, Image, Tag, Info } from "lucide-svelte";
+
+  let { closeModal, formData, action = "create", plantId = null } = $props();
+
+  let localData = $derived({
+    ...formData
+  });
+
+  const handleBackdropClick = (e) => {
+    if (e.target.id === "modal-backdrop") closeModal();
+  };
+
+  const handleModalContentClick = (e) => {
+    e.stopPropagation();
+  };
+</script>
+
+<div
+  id="modal-backdrop"
+  class="text-start fixed inset-0 bg-green-100/50 backdrop-blur-sm flex items-center justify-center p-4 sm:p-8 z-50 cursor-default"
+  role="presentation"
+  onclick={handleBackdropClick}
+  onkeydown={(e) => {
+    if (e.key === "Escape") closeModal();
+  }}
+>
+  <div
+    class="bg-white shadow-2xl shadow-gray-400 w-full max-w-2xl max-h-[95vh] sm:max-h-[90vh] rounded-xl overflow-hidden animate-in fade-in duration-300 flex flex-col h-full sm:h-auto cursor-default outline-none"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+    tabindex="0"
+    onclick={handleModalContentClick}
+    onkeydown={(e) => e.stopPropagation()}
+  >
+    {#if plantId}
+      <input type="hidden" name="id" value={plantId} />
+    {/if}
+
+    <header class="sticky top-0 bg-white p-6 border-b border-gray-100 flex items-center justify-between z-10 shrink-0">
+      <h2 id="modal-title" class="text-3xl font-extrabold text-gray-800">
+        {action === "update" ? "Edit Plant" : "New Plant Details"}
+      </h2>
+
+      <button
+        type="button"
+        onclick={closeModal}
+        class="p-2 rounded-full text-gray-500 hover:bg-gray-100 transition focus:outline-none focus:ring-2 focus:ring-green-500 cursor-pointer"
+        aria-label="Close modal"
+      >
+        <X class="w-6 h-6" />
+      </button>
+    </header>
+
+    <div class="p-8 space-y-10 grow overflow-y-auto">
+      <section class="space-y-6">
+        <h3 class="text-2xl font-bold text-gray-700 flex items-center gap-3 border-b pb-2 border-green-100">
+          <Leaf class="w-6 h-6 text-green-600" /> Basic info
+        </h3>
+
+        <div class="grid grid-cols-1 gap-4">
+          <div class="flex flex-col">
+            <label for="name" class="font-semibold text-gray-700 mb-1">
+              Name <span class="text-red-500">*</span>
+            </label>
+            <input
+              name="name"
+              id="name"
+              type="text"
+              bind:value={localData.name}
+              required
+              placeholder="Apple tree"
+              class="px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 transition"
+            />
+          </div>
+
+          <div class="flex flex-col">
+            <label for="scientificName" class="font-semibold text-gray-700 mb-1">
+              Scientific name
+            </label>
+            <input
+              name="scientificName"
+              id="scientificName"
+              type="text"
+              bind:value={localData.scientificName}
+              placeholder="Malus domestica"
+              class="px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 transition"
+            />
+          </div>
+
+          <div class="flex flex-col">
+            <label for="description" class="font-semibold text-gray-700 mb-1 flex items-center gap-1">
+              <Info class="w-4 h-4 text-green-600" /> Description
+            </label>
+            <textarea
+              name="description"
+              id="description"
+              bind:value={localData.description}
+              rows="4"
+              placeholder="Short description / care notes"
+              class="px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 transition resize-none"
+            ></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="space-y-6">
+        <h3 class="text-2xl font-bold text-gray-700 flex items-center gap-3 border-b pb-2 border-green-100">
+          <Image class="w-6 h-6 text-green-600" /> Media
+        </h3>
+
+        <div class="flex flex-col">
+          <label for="image" class="font-semibold text-gray-700 mb-1">Image URL</label>
+          <input
+            name="image"
+            id="image"
+            type="url"
+            bind:value={localData.image}
+            placeholder="https://..."
+            class="px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 transition"
+          />
+        </div>
+      </section>
+
+      <section class="space-y-6">
+        <h3 class="text-2xl font-bold text-gray-700 flex items-center gap-3 border-b pb-2 border-green-100">
+          <Tag class="w-6 h-6 text-green-600" /> Type
+        </h3>
+
+        <div class="flex flex-col">
+          <label for="plantTypeID" class="font-semibold text-gray-700 mb-1">
+            Plant Type ID <span class="text-red-500">*</span>
+          </label>
+          <input
+            name="plantTypeID"
+            id="plantTypeID"
+            type="number"
+            min="1"
+            bind:value={localData.plantTypeID}
+            required
+            class="px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 transition"
+          />
+          <p class="text-xs text-gray-500 mt-2">
+            Later we can replace this with a dropdown from your PlantTypes endpoint.
+          </p>
+        </div>
+      </section>
+    </div>
+
+    <div class="p-6 border-t border-gray-100 bg-white z-10 shrink-0">
+      <button
+        type="submit"
+        class="w-full py-4 rounded-xl text-white font-extrabold text-xl bg-green-600 hover:bg-green-700 shadow-xl cursor-pointer transition-all active:scale-[0.98]"
+      >
+        {action === "update" ? "Save Changes" : "Create Plant"}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/routes/(app)/+layout.server.js
+++ b/src/routes/(app)/+layout.server.js
@@ -28,7 +28,7 @@ export const load = async ({ cookies }) => {
     });
 
     return { user, events, token, eventLabels, plants };
-  } catch (err) {
+  } catch {
     throw error(500, 'Failed to load dashboard data');
   }
 };

--- a/src/routes/(app)/+layout.server.js
+++ b/src/routes/(app)/+layout.server.js
@@ -18,7 +18,11 @@ export const load = async ({ cookies, params, fetch }) => {
       headers: { Authorization: `Bearer ${token}` }
     });
 
-    return { user, events, token };
+    const plants = await getData(`${PUBLIC_API_URL}/plants/`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    return { user, events, plants, token };
   } catch (err) {
     throw error(500, 'Failed to load dashboard data');
   }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,9 +1,13 @@
+<svelte:head>
+  <title>Food Forest</title>
+</svelte:head>
+
 <script lang="ts">
   import '../../app.css';
 
   import { page } from '$app/stores'; 
   import { 
-    Home,
+    House,
     Trophy, 
     Calendar, 
     ShoppingBag,
@@ -12,7 +16,8 @@
 
   // Define navigation items
   const navItems = [
-    { href: '/', icon: Home, label: 'Home' },
+    { href: '/', icon: House, label: 'Home' },
+    { href: '/plants', icon: Leaf, label: 'Plants' },
     { href: '/events', icon: Calendar, label: 'Events' },
     { href: '/ranks', icon: Trophy, label: 'Ranks' },
     { href: '/shop', icon: ShoppingBag, label: 'Shop' },

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,15 +1,15 @@
 <script>
-  import { Trophy, Leaf, Calendar } from "lucide-svelte";
-  import Event from "$lib/components/+Event.svelte";
-  import Plant from "$lib/components/+Plant.svelte";
-  import MapPlantItem from "$lib/components/+MapPlantItem.svelte";
-  import { goto } from "$app/navigation";
+  import { Trophy, Leaf, Calendar } from 'lucide-svelte';
+  import Event from '$lib/components/+Event.svelte';
+  import Plant from '$lib/components/+Plant.svelte';
+  import MapPlantItem from '$lib/components/+MapPlantItem.svelte';
+  import { goto } from '$app/navigation';
 
-  let { data } = $props();
+  const { data } = $props();
 
   // ✅ Svelte 5 reactive derived values (no "captured locally" warning)
-  let events = $derived(data?.events?.data ?? data?.events ?? []);
-  let plants = $derived(data?.plants?.data ?? data?.plants ?? []);
+  const events = $derived(data?.events?.data ?? data?.events ?? []);
+  const plants = $derived(data?.plants?.data ?? data?.plants ?? []);
 </script>
 
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,63 +1,17 @@
 <script>
   import { Trophy, Leaf, Calendar } from "lucide-svelte";
-
   import Event from "$lib/components/+Event.svelte";
   import Plant from "$lib/components/+Plant.svelte";
   import MapPlantItem from "$lib/components/+MapPlantItem.svelte";
-    import { goto } from "$app/navigation";
+  import { goto } from "$app/navigation";
 
   let { data } = $props();
-  const events = data.events.data;
 
-  // --- Mock Data ---
-  const PLANTS = [
-    {
-      id: 1,
-      name: "Mango",
-      type: "Fruit Tree",
-      status: "critical",
-      image: "🥭",
-      statusDetails: "Water: Sufficient, Sunlight: Critical",
-      mapPosition: { top: "65%", left: "30%" },
-    },
-    {
-      id: 2,
-      name: "Carrot",
-      type: "Root Vegetable",
-      status: "warning",
-      image: "🥕",
-      statusDetails: "Water: Sufficient, Sunlight: Insufficient",
-      mapPosition: { top: "35%", left: "70%" },
-    },
-    {
-      id: 3,
-      name: "Tomato",
-      type: "Heritage Beefsteak",
-      status: "healthy",
-      image: "🍅",
-      statusDetails: "Water: Sufficient, Sunlight: Sufficient",
-      mapPosition: { top: "50%", left: "45%" },
-    },
-    {
-      id: 4,
-      name: "Pear",
-      type: "Fruit Tree",
-      status: "healthy",
-      image: "🍐",
-      statusDetails: "Water: Sufficient, Sunlight: Sufficient",
-      mapPosition: { top: "40%", left: "25%" },
-    },
-    {
-      id: 5,
-      name: "Basil",
-      type: "Herb",
-      status: "healthy",
-      image: "🌿",
-      statusDetails: "Water: Sufficient, Sunlight: Sufficient",
-      mapPosition: { top: "70%", left: "60%" },
-    },
-  ];
+  // ✅ Svelte 5 reactive derived values (no "captured locally" warning)
+  let events = $derived(data?.events?.data ?? data?.events ?? []);
+  let plants = $derived(data?.plants?.data ?? data?.plants ?? []);
 </script>
+
 
 <div class="max-w-7xl mx-auto w-full">
   <header class="flex justify-between items-center px-6 pt-8 pb-6 md:pb-10">
@@ -102,7 +56,7 @@
         />
 
         <!-- Plants -->
-        {#each PLANTS as plant}
+        {#each plants as plant}
           <MapPlantItem {plant} />
         {/each}
       </div>
@@ -110,7 +64,7 @@
       <div
         class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-3 pb-4"
       >
-        {#each PLANTS as plant}
+        {#each plants as plant}
           <Plant {plant} />
         {/each}
       </div>

--- a/src/routes/(app)/events/+page.svelte
+++ b/src/routes/(app)/events/+page.svelte
@@ -89,7 +89,7 @@
         {/if}
       </div>
 
-      {#if user?.role === 'GREEN_OFFICE_MEMBER'}
+      {#if user?.role === 'GREEN_OFFICE_MEMBER', 'USER'}
         <button
           onclick={openModal}
           class="p-2.5 rounded-lg bg-green-700 hover:bg-green-800 text-white transition-colors shadow-md cursor-pointer shrink-0"

--- a/src/routes/(app)/events/+page.svelte
+++ b/src/routes/(app)/events/+page.svelte
@@ -1,16 +1,16 @@
 <script>
-
-  import { Search, X, Calendar, Check, Plus, MapPin, Clock } from 'lucide-svelte';
+  import { Search, X, Calendar, Check, Plus, MapPin } from 'lucide-svelte';
   import Event from '$lib/components/+Event.svelte';
-  import { page } from '$app/stores';
   import { enhance } from '$app/forms';
   import CreateUpdateModal from '$lib/components/events/+CreateUpdateModal.svelte';
 
   const { data } = $props();
 
+  const filters = ['All'];
+
   let filter = $state('All');
-  let filterCategory = $state("All");
-  let searchQuery = $state("");
+  let filterCategory = $state('All');
+  let searchQuery = $state('');
   let isModalOpen = $state(false);
 
   const formData = $state({
@@ -24,14 +24,14 @@
     location: '',
     points: 100,
     studyPoints: 0,
-    maxParticipants: 0,
+    maxParticipants: 0
   });
 
   const events = data.events.data;
-  const user = $page.data?.user;
-  const eventLabels = $page.data?.eventLabels.data;
+  const user = data.user;
+  const eventLabels = data.eventLabels.data;
 
-  // Reactive Logic for Main Feed
+
   const filteredEvents = $derived(
     events.filter((event) => {
       const query = searchQuery.toLowerCase();
@@ -40,44 +40,34 @@
         (event.subtitle && event.subtitle.toLowerCase().includes(query));
 
       const matchesCategory =
-        filterCategory === "All" ||
-        (event.label?.category ?? "") === filterCategory;
+        filterCategory === 'All' || (event.label?.category ?? '') === filterCategory;
 
       return matchesSearch && matchesCategory;
-    }),
+    })
   );
 
-  let registeredEvents = $derived(
+  const registeredEvents = $derived(
     events.filter((event) =>
-      user?.eventRegistrations?.some((reg) => reg.eventId === event.id),
-    ),
+      user?.eventRegistrations?.some((reg) => reg.eventId === event.id)
+    )
   );
 
   const openModal = () => (isModalOpen = true);
   const closeModal = () => (isModalOpen = false);
 </script>
 
-<div
-  class="flex flex-col space-y-6 pb-24 bg-stone-50 min-h-screen cursor-default"
->
+<div class="flex flex-col space-y-6 pb-24 bg-stone-50 min-h-screen cursor-default">
   <header class="px-6 pt-10 pb-4 bg-white shadow-sm rounded-b-3xl">
-    <div
-      class="flex flex-col md:flex-row md:justify-between md:items-end gap-4 mb-4"
-    >
+    <div class="flex flex-col md:flex-row md:justify-between md:items-end gap-4 mb-4">
       <div>
-        <div
-          class="text-xs uppercase tracking-widest text-green-700 font-bold mb-1"
-        >
+        <div class="text-xs uppercase tracking-widest text-green-700 font-bold mb-1">
           Fruit Forest
         </div>
-        <h1 class="font-serif text-4xl italic font-bold text-stone-900">
-          Events
-        </h1>
+        <h1 class="font-serif text-4xl italic font-bold text-stone-900">Events</h1>
       </div>
+
       <div class="flex items-center gap-2 w-full md:w-auto">
-        <div
-          class="flex-1 md:flex-none flex items-center bg-stone-100 rounded-lg p-2 md:w-64"
-        >
+        <div class="flex-1 md:flex-none flex items-center bg-stone-100 rounded-lg p-2 md:w-64">
           <Search class="w-4 h-4 text-stone-400 ml-1" />
           <input
             type="text"
@@ -86,16 +76,13 @@
             class="bg-transparent border-none outline-none text-sm w-full text-stone-800 px-2 cursor-text"
           />
           {#if searchQuery}
-            <button
-              class="cursor-pointer p-1"
-              onclick={() => (searchQuery = "")}
-            >
+            <button class="cursor-pointer p-1" onclick={() => (searchQuery = '')}>
               <X class="w-4 h-4 text-stone-400 hover:text-stone-600" />
             </button>
           {/if}
         </div>
 
-        {#if user?.role === "GREEN_OFFICE_MEMBER"}
+        {#if user?.role === 'GREEN_OFFICE_MEMBER'}
           <button
             onclick={openModal}
             class="p-2.5 rounded-lg bg-green-700 hover:bg-green-800 text-white transition-colors shadow-md cursor-pointer shrink-0"
@@ -107,94 +94,96 @@
       </div>
     </div>
 
-    <p
-      class="text-stone-600 italic border-l-2 border-green-500 pl-3 py-1 text-sm md:text-base"
-    >
+    <p class="text-stone-600 italic border-l-2 border-green-500 pl-3 py-1 text-sm md:text-base">
       Join activities that protect nature & earn rewards.
     </p>
-  <div class="flex overflow-x-auto space-x-2 mt-6 pb-1 scrollbar-hide">
-    {#each filters as f}
-      <button
-        onclick={() => (filter = f)}
-        class={`px-4 py-1.5 rounded-full text-xs font-bold whitespace-nowrap transition-colors border cursor-pointer ${
-          filter === f
-            ? 'bg-green-700 text-white border-green-700'
-            : 'bg-white text-stone-600 border-stone-200 hover:border-green-300'
-        }`}
-      >
-        {f}
-      </button>
-    {/each}
-  </div>
-</header>
-  {#if registeredEvents.length > 0 && !searchQuery && filter === 'All'}
-    <section class="px-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
 
+    <!-- Top-level filter pills -->
     <div class="flex overflow-x-auto space-x-2 mt-6 pb-1 scrollbar-hide">
-      <!-- Filter Buttons -->
-      {#each eventLabels as label}
+      {#each filters as f}
         <button
-          onclick={() => (filterCategory = label.category)}
+          onclick={() => (filter = f)}
           class={`px-4 py-1.5 rounded-full text-xs font-bold whitespace-nowrap transition-colors border cursor-pointer ${
-            filterCategory === label.category
-              ? "bg-green-700 text-white border-green-700"
-              : "bg-white text-stone-600 border-stone-200 hover:border-green-300"
+            filter === f
+              ? 'bg-green-700 text-white border-green-700'
+              : 'bg-white text-stone-600 border-stone-200 hover:border-green-300'
           }`}
         >
-          {label.category}
+          {f}
         </button>
       {/each}
     </div>
   </header>
 
-  {#if registeredEvents.length > 0 && !searchQuery && filterCategory == "All"}
-    <section
-      class="px-6 animate-in fade-in slide-in-from-bottom-4 duration-500"
-    >
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="font-serif text-2xl italic font-bold text-stone-800">
-          Registered Events
-        </h2>
-        <span
-          class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold"
+  <!-- Category filter buttons (only show in the scenario you originally wanted) -->
+  {#if registeredEvents.length > 0 && !searchQuery && filter === 'All'}
+    <div class="px-6">
+      <div class="flex overflow-x-auto space-x-2 mt-2 pb-1 scrollbar-hide">
+        <button
+          onclick={() => (filterCategory = 'All')}
+          class={`px-4 py-1.5 rounded-full text-xs font-bold whitespace-nowrap transition-colors border cursor-pointer ${
+            filterCategory === 'All'
+              ? 'bg-green-700 text-white border-green-700'
+              : 'bg-white text-stone-600 border-stone-200 hover:border-green-300'
+          }`}
         >
+          All
+        </button>
+
+        {#each eventLabels as label}
+          <button
+            onclick={() => (filterCategory = label.category)}
+            class={`px-4 py-1.5 rounded-full text-xs font-bold whitespace-nowrap transition-colors border cursor-pointer ${
+              filterCategory === label.category
+                ? 'bg-green-700 text-white border-green-700'
+                : 'bg-white text-stone-600 border-stone-200 hover:border-green-300'
+            }`}
+          >
+            {label.category}
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  {#if registeredEvents.length > 0 && !searchQuery && filterCategory === 'All'}
+    <section class="px-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="font-serif text-2xl italic font-bold text-stone-800">Registered Events</h2>
+        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold">
           {registeredEvents.length} Registered
         </span>
       </div>
 
-      <div
-        class="flex overflow-x-auto space-x-4 pb-4 scrollbar-hide -mx-2 px-2"
-      >
+      <div class="flex overflow-x-auto space-x-4 pb-4 scrollbar-hide -mx-2 px-2">
         {#each registeredEvents as event (event.id)}
           <a
             href={`/events/${event.id}`}
             class="flex-shrink-0 w-72 bg-white rounded-2xl shadow-sm border border-stone-200 p-4 hover:shadow-md transition-shadow group"
           >
             <div class="flex gap-4">
-              <div
-                class="w-16 h-16 rounded-xl overflow-hidden bg-stone-100 shrink-0"
-              >
+              <div class="w-16 h-16 rounded-xl overflow-hidden bg-stone-100 shrink-0">
                 <img
-                  src={event.thumbnail || "https://picsum.photos/200"}
+                  src={event.thumbnail || 'https://picsum.photos/200'}
                   alt={event.title}
                   class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
                 />
               </div>
+
               <div class="flex-1 min-w-0">
                 <div class="flex items-center text-green-700 gap-1 mb-1">
                   <Check class="w-3 h-3" />
-                  <span class="text-[10px] font-black uppercase tracking-widest"
-                    >Enrolled</span
-                  >
+                  <span class="text-[10px] font-black uppercase tracking-widest">Enrolled</span>
                 </div>
-                <h3 class="font-bold text-stone-900 text-sm truncate">
-                  {event.title}
-                </h3>
+
+                <h3 class="font-bold text-stone-900 text-sm truncate">{event.title}</h3>
+
                 <div class="flex flex-col gap-1 mt-2 text-stone-500">
                   <div class="flex items-center gap-1.5 text-[11px]">
                     <Calendar class="w-3 h-3" />
                     <span>{event.date || event.startAt}</span>
                   </div>
+
                   {#if event.location}
                     <div class="flex items-center gap-1.5 text-[11px]">
                       <MapPin class="w-3 h-3" />
@@ -214,16 +203,12 @@
   <main class="px-6">
     <div class="flex items-center justify-between mb-4">
       <h2 class="font-serif text-2xl italic font-bold text-stone-800">
-        {filterCategory == "All"
-          ? "Explore Events"
-          : `${filterCategory} Events`}
+        {filterCategory === 'All' ? 'Explore Events' : `${filterCategory} Events`}
       </h2>
     </div>
 
     {#if filteredEvents.length === 0}
-      <div
-        class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300"
-      >
+      <div class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300">
         <p class="text-stone-400">
           No events found matching "{searchQuery}" in {filterCategory}.
         </p>
@@ -238,9 +223,7 @@
   </main>
 
   {#if isModalOpen}
-    <div
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm"
-    >
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm">
       <form
         method="POST"
         action="?/create"

--- a/src/routes/(app)/events/[id]/+page.svelte
+++ b/src/routes/(app)/events/[id]/+page.svelte
@@ -152,11 +152,9 @@
       <span
         class="text-sm font-bold tracking-wider text-green-700 bg-white/70 backdrop-blur-sm px-4 py-1.5 rounded-full shadow-md"
       >
-<<<<<<< HEAD
+
         {event.category || 'Eco Event'}
-=======
-        {event.label.category}
->>>>>>> 9fb37853efd12acbcac79c58961cf339ce4cb05d
+        
       </span>
       {/if}
       <h1

--- a/src/routes/(app)/plants/+page.server.js
+++ b/src/routes/(app)/plants/+page.server.js
@@ -1,7 +1,6 @@
 import { PUBLIC_API_URL } from '$env/static/public';
-import { fail } from '@sveltejs/kit';
+import { fail, error, redirect } from '@sveltejs/kit';
 import { getData } from '$lib/helpers/ajaxhelper.js';
-import { error, redirect } from '@sveltejs/kit';
 
 export const load = async ({ cookies }) => {
   const token = cookies.get('token');

--- a/src/routes/(app)/plants/+page.server.js
+++ b/src/routes/(app)/plants/+page.server.js
@@ -1,0 +1,82 @@
+import { PUBLIC_API_URL } from '$env/static/public';
+import { fail } from '@sveltejs/kit';
+import { getData } from '$lib/helpers/ajaxhelper.js';
+import { error, redirect } from '@sveltejs/kit';
+
+export const load = async ({ cookies }) => {
+  const token = cookies.get('token');
+  if (!token) throw redirect(302, '/login');
+
+  try {
+    const rawPlants = await getData(`${PUBLIC_API_URL}/plants`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    // normalize: support either { data: [...] } or [...]
+    const plants = rawPlants?.data ?? rawPlants ?? [];
+
+    return { plants };
+  } catch (err) {
+    console.error('❌ Failed to load plants:', err);
+    throw error(500, err?.message ?? 'Failed to load plants');
+  }
+};
+
+export const actions = {
+  create: async ({ request, fetch, cookies }) => {
+    const token = cookies.get('token');
+    if (!token) return fail(401, { error: 'Not authenticated' });
+
+    const data = await request.formData();
+    const plantData = mapFormDataToPayload(data);
+
+    const response = await fetch(`${PUBLIC_API_URL}/plants`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(plantData)
+    });
+
+    if (response.ok) return { success: true };
+
+    const errorData = await response.json().catch(() => ({}));
+    return fail(response.status, { error: errorData.message || 'Failed to create plant' });
+  },
+
+  update: async ({ request, fetch, cookies }) => {
+    const token = cookies.get('token');
+    if (!token) return fail(401, { error: 'Not authenticated' });
+
+    const data = await request.formData();
+    const id = data.get('id');
+    if (!id) return fail(400, { error: 'Missing plant ID' });
+
+    const plantData = mapFormDataToPayload(data);
+
+    const response = await fetch(`${PUBLIC_API_URL}/plants/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(plantData)
+    });
+
+    if (response.ok) return { success: true };
+
+    const errorData = await response.json().catch(() => ({}));
+    return fail(response.status, { error: errorData.message || 'Update failed' });
+  }
+};
+
+function mapFormDataToPayload(data) {
+  return {
+    name: data.get('name'),
+    scientificName: data.get('scientificName'),
+    description: data.get('description'),
+    image: data.get('image'),
+    plantTypeID: Number(data.get('plantTypeID'))
+  };
+}

--- a/src/routes/(app)/plants/+page.svelte
+++ b/src/routes/(app)/plants/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import { Search, X, Plus, Leaf } from 'lucide-svelte';
+  import { page } from '$app/stores';
+  import { enhance } from '$app/forms';
+  import Plant from '$lib/components/+Plant.svelte';
+  import CreateUpdateModal from '$lib/components/plants/+CreateUpdateModal.svelte';
+
+
+  export let data: any;
+
+  let searchQuery = '';
+  let isModalOpen = false;
+
+  // adjust based on your API shape: either data.plants.data or data.plants
+  const plants = data?.plants ?? [];
+  const user = $page.data?.user;
+
+  let formData = {
+    id: '',
+    name: '',
+    scientificName: '',
+    description: '',
+    image: '',
+    plantTypeID: 1
+  };
+
+  const openModal = () => (isModalOpen = true);
+  const closeModal = () => (isModalOpen = false);
+
+  $: filteredPlants = plants.filter((p) => {
+    const q = searchQuery.toLowerCase();
+    return (
+      p.name?.toLowerCase().includes(q) ||
+      p.scientificName?.toLowerCase().includes(q)
+    );
+  });
+</script>
+
+<div class="flex flex-col space-y-6 pb-24 bg-stone-50 min-h-screen cursor-default">
+  <header class="px-6 pt-10 pb-4 bg-white shadow-sm rounded-b-3xl">
+    <div class="flex flex-col md:flex-row md:justify-between md:items-end gap-4 mb-4">
+      <div>
+        <div class="text-xs uppercase tracking-widest text-green-700 font-bold mb-1">
+          Food Forest
+        </div>
+        <h1 class="font-serif text-4xl italic font-bold text-stone-900">
+          Plants
+        </h1>
+      </div>
+
+      <div class="flex items-center gap-2 w-full md:w-auto">
+        <div class="flex-1 md:flex-none flex items-center bg-stone-100 rounded-lg p-2 md:w-64">
+          <Search class="w-4 h-4 text-stone-400 ml-1" />
+          <input
+            type="text"
+            placeholder="Search plants..."
+            bind:value={searchQuery}
+            class="bg-transparent border-none outline-none text-sm w-full text-stone-800 px-2 cursor-text"
+          />
+          {#if searchQuery}
+            <button class="cursor-pointer p-1" on:click={() => (searchQuery = '')}>
+              <X class="w-4 h-4 text-stone-400 hover:text-stone-600" />
+            </button>
+          {/if}
+        </div>
+
+        {#if user?.role === 'GREEN_OFFICE_MEMBER'}
+          <button
+            on:click={openModal}
+            class="p-2.5 rounded-lg bg-green-700 hover:bg-green-800 text-white transition-colors shadow-md cursor-pointer shrink-0"
+            title="Create New Plant"
+          >
+            <Plus class="w-5 h-5" />
+          </button>
+        {/if}
+      </div>
+    </div>
+
+    <p class="text-stone-600 italic border-l-2 border-green-500 pl-3 py-1 text-sm md:text-base">
+      Add plants, manage details, and track ownership.
+    </p>
+  </header>
+
+  <main class="px-6">
+  {#if filteredPlants.length === 0}
+    <div class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300">
+      <p class="text-stone-400">No plants found matching "{searchQuery}".</p>
+    </div>
+  {:else}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {#each filteredPlants as plant (plant.id)}
+            <Plant {plant} />
+        {/each}
+    </div>
+  {/if}
+</main>
+
+
+  {#if isModalOpen}
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm">
+      <form
+        method="POST"
+        action="?/create"
+        class="w-full max-w-2xl"
+        use:enhance={() => {
+          return async ({ result }) => {
+            if (result.type === 'success') {
+              location.reload();
+            }
+          };
+        }}
+      >
+        <CreateUpdateModal {closeModal} {formData} action="Create" />
+      </form>
+    </div>
+  {/if}
+</div>

--- a/src/routes/(app)/plants/+page.svelte
+++ b/src/routes/(app)/plants/+page.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
-  import { Search, X, Plus, Leaf } from 'lucide-svelte';
-  import { page } from '$app/stores';
+  import { Search, X, Plus } from 'lucide-svelte';
   import { enhance } from '$app/forms';
   import Plant from '$lib/components/+Plant.svelte';
   import CreateUpdateModal from '$lib/components/plants/+CreateUpdateModal.svelte';
-
 
   export let data: any;
 
   let searchQuery = '';
   let isModalOpen = false;
 
-  // adjust based on your API shape: either data.plants.data or data.plants
   const plants = data?.plants ?? [];
-  const user = $page.data?.user;
 
-  let formData = {
+  const user = data?.user;
+
+  const formData = {
     id: '',
     name: '',
     scientificName: '',
@@ -27,7 +25,9 @@
   const openModal = () => (isModalOpen = true);
   const closeModal = () => (isModalOpen = false);
 
-  $: filteredPlants = plants.filter((p) => {
+  let filteredPlants = plants;
+
+  $: filteredPlants = plants.filter((p: any) => {
     const q = searchQuery.toLowerCase();
     return (
       p.name?.toLowerCase().includes(q) ||
@@ -82,19 +82,18 @@
   </header>
 
   <main class="px-6">
-  {#if filteredPlants.length === 0}
-    <div class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300">
-      <p class="text-stone-400">No plants found matching "{searchQuery}".</p>
-    </div>
-  {:else}
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    {#if filteredPlants.length === 0}
+      <div class="text-center py-20 bg-white rounded-3xl border border-dashed border-stone-300">
+        <p class="text-stone-400">No plants found matching "{searchQuery}".</p>
+      </div>
+    {:else}
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {#each filteredPlants as plant (plant.id)}
-            <Plant {plant} />
+          <Plant {plant} />
         {/each}
-    </div>
-  {/if}
-</main>
-
+      </div>
+    {/if}
+  </main>
 
   {#if isModalOpen}
     <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm">

--- a/src/routes/(app)/plants/[id]/+page.server.js
+++ b/src/routes/(app)/plants/[id]/+page.server.js
@@ -1,0 +1,38 @@
+// src/routes/plants/[id]/+page.server.ts
+import { getData } from '$lib/helpers/ajaxhelper.js';
+import { PUBLIC_API_URL } from '$env/static/public';
+import { error, redirect } from '@sveltejs/kit';
+
+export const load = async ({ cookies, params }) => {
+  const token = cookies.get('token');
+  const plantId = params.id;
+
+  if (!token) {
+    throw redirect(302, '/login');
+  }
+
+  try {
+    const user = await getData(`${PUBLIC_API_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    // Plant detail
+    const plant = await getData(`${PUBLIC_API_URL}/plants/${plantId}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    /**
+     * Optional:
+     * If you have a PlantedPlants endpoint, fetch it here so we can check ownerID.
+     * Example (change to your real endpoint):
+     *
+     * const plantedPlant = await getData(`${PUBLIC_API_URL}/plantedplants/by-plant/${plantId}`, {
+     *   headers: { Authorization: `Bearer ${token}` }
+     * });
+     */
+
+    return { user, plant, token };
+  } catch (err) {
+    throw error(500, 'Failed to load plant data');
+  }
+};

--- a/src/routes/(app)/plants/[id]/+page.server.js
+++ b/src/routes/(app)/plants/[id]/+page.server.js
@@ -1,49 +1,68 @@
-// src/routes/plants/[id]/+page.server.ts
-import {getData} from '$lib/helpers/ajaxhelper.js';
-import {PUBLIC_API_URL} from '$env/static/public';
-import {error, redirect} from '@sveltejs/kit';
+// src/routes/plants/[id]/+page.server.js
+import { getData } from '$lib/helpers/ajaxhelper.js';
+import { PUBLIC_API_URL } from '$env/static/public';
+import { error, redirect, fail } from '@sveltejs/kit';
 
-export const load = async ({cookies, params}) => {
+export const load = async ({ cookies, params }) => {
+  const token = cookies.get('token');
+  const plantId = params.id;
+
+  if (!token) throw redirect(302, '/login');
+
+  try {
+    const user = await getData(`${PUBLIC_API_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    const rawPlant = await getData(`${PUBLIC_API_URL}/plants/${plantId}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const plant = rawPlant?.data ?? rawPlant;
+
+    const rawOwnerHistory = await getData(`${PUBLIC_API_URL}/plants/${plantId}/owner-history`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const ownerHistory = rawOwnerHistory?.data ?? rawOwnerHistory;
+
+    return { user, plant, ownerHistory, token };
+  } catch (err) {
+    console.error('❌ Plant page load failed:', err);
+    throw error(500, err?.message ?? 'Failed to load plant data');
+  }
+};
+
+export const actions = {
+  delete: async ({ cookies, params, fetch }) => {
     const token = cookies.get('token');
-    const plantId = params.id;
+    if (!token) throw redirect(302, '/login');
 
-    if (!token) {
-        throw redirect(302, '/login');
+    const res = await fetch(`${PUBLIC_API_URL}/plants/${params.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    if (res.status === 204) {
+      throw redirect(303, '/plants?deleted=1');
     }
 
-    try {
-        const user = await getData(`${PUBLIC_API_URL}/users/me`, {
-            headers: {
-                Authorization: `Bearer ${token}`
-            }
-        });
+    return fail(res.status, { message: 'Delete failed' });
+  },
 
+  // ✅ NEW: watered today
+  wateredToday: async ({ cookies, params, fetch }) => {
+    const token = cookies.get('token');
+    if (!token) throw redirect(302, '/login');
 
-        // Plant detail
-        const rawPlant = await getData(`${PUBLIC_API_URL}/plants/${plantId}`, {
-            headers: {
-                Authorization: `Bearer ${token}`
-            }
-        });
+    const res = await fetch(`${PUBLIC_API_URL}/plants/${params.id}/watered-today`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    });
 
-        // normalize (same idea as rewards)
-        const plant = rawPlant
-            ?.data ?? rawPlant;
-
-        return {user, plant, token};
-
-        /**
-     * Optional:
-     * If you have a PlantedPlants endpoint, fetch it here so we can check ownerID.
-     * Example (change to your real endpoint):
-     *
-     * const plantedPlant = await getData(`${PUBLIC_API_URL}/plantedplants/by-plant/${plantId}`, {
-     *   headers: { Authorization: `Bearer ${token}` }
-     * });
-     */
-
-        return {user, plant, token};
-    } catch (err) {
-        throw error(500, 'Failed to load plant data');
+    if (!res.ok) {
+      return fail(res.status, { message: 'Watering failed' });
     }
+
+    // reload same page so waterLevel updates in UI
+    throw redirect(303, `/plants/${params.id}?watered=1`);
+  }
 };

--- a/src/routes/(app)/plants/[id]/+page.server.js
+++ b/src/routes/(app)/plants/[id]/+page.server.js
@@ -1,27 +1,38 @@
 // src/routes/plants/[id]/+page.server.ts
-import { getData } from '$lib/helpers/ajaxhelper.js';
-import { PUBLIC_API_URL } from '$env/static/public';
-import { error, redirect } from '@sveltejs/kit';
+import {getData} from '$lib/helpers/ajaxhelper.js';
+import {PUBLIC_API_URL} from '$env/static/public';
+import {error, redirect} from '@sveltejs/kit';
 
-export const load = async ({ cookies, params }) => {
-  const token = cookies.get('token');
-  const plantId = params.id;
+export const load = async ({cookies, params}) => {
+    const token = cookies.get('token');
+    const plantId = params.id;
 
-  if (!token) {
-    throw redirect(302, '/login');
-  }
+    if (!token) {
+        throw redirect(302, '/login');
+    }
 
-  try {
-    const user = await getData(`${PUBLIC_API_URL}/users/me`, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    try {
+        const user = await getData(`${PUBLIC_API_URL}/users/me`, {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        });
 
-    // Plant detail
-    const plant = await getData(`${PUBLIC_API_URL}/plants/${plantId}`, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
 
-    /**
+        // Plant detail
+        const rawPlant = await getData(`${PUBLIC_API_URL}/plants/${plantId}`, {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        });
+
+        // normalize (same idea as rewards)
+        const plant = rawPlant
+            ?.data ?? rawPlant;
+
+        return {user, plant, token};
+
+        /**
      * Optional:
      * If you have a PlantedPlants endpoint, fetch it here so we can check ownerID.
      * Example (change to your real endpoint):
@@ -31,8 +42,8 @@ export const load = async ({ cookies, params }) => {
      * });
      */
 
-    return { user, plant, token };
-  } catch (err) {
-    throw error(500, 'Failed to load plant data');
-  }
+        return {user, plant, token};
+    } catch (err) {
+        throw error(500, 'Failed to load plant data');
+    }
 };

--- a/src/routes/(app)/plants/[id]/+page.svelte
+++ b/src/routes/(app)/plants/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <!-- src/routes/plants/[id]/+page.svelte -->
 <script lang="ts">
   import LogoutModal from '$lib/components/LogoutModal.svelte';
-  import { page } from '$app/stores';
 
   import {
     ChevronLeft,
@@ -12,7 +11,6 @@
     Tag,
     Calendar,
     MapPin,
-    Pencil,
     Trash2,
     CheckCircle
   } from 'lucide-svelte';
@@ -21,18 +19,19 @@
   let showDeletedToast = false;
 
   onMount(() => {
-    if ($page.url.searchParams.get('deleted') === '1') {
-      showDeletedToast = true;
+  const deleted = new URL(window.location.href).searchParams.get('deleted');
+  if (deleted === '1') {
+    showDeletedToast = true;
 
-      // auto-hide after 3s
-      setTimeout(() => {
-        showDeletedToast = false;
-      }, 3000);
-    }
-  });
+    setTimeout(() => {
+      showDeletedToast = false;
+    }, 3000);
+  }
+});
+
 
   export let data;
-  const { user, plant, ownerHistory, token } = data;
+  const { plant, ownerHistory, token } = data;
 
   let showDeleteConfirm = false;
   let showWaterConfirm = false;
@@ -41,6 +40,7 @@
   const isOwner = true;
 
   // DELETE
+  /**
   async function deletePlant() {
     const res = await fetch(`/api/plants/${plant.id}`, {
       method: 'DELETE',
@@ -56,27 +56,30 @@
 
     window.location.href = '/';
   }
+    */
 
+  /**
   function goToEdit() {
     window.location.href = `/plants/${plant.id}/edit`;
   }
+    */
 
   async function wateredToday() {
-    const res = await fetch(`/api/plants/${plant.id}/watered-today`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    });
-
-    if (!res.ok) {
-      alert("Couldn't save watering. Please try again.");
-      return;
+  const res = await fetch(`/plants/${plant.id}/watered-today`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`
     }
+  });
 
-    // Refresh page data so latestPlanted.waterLevel becomes 0 in the UI
-    location.reload();
+  if (!res.ok) {
+    alert('Couldn\'t save watering. Please try again.');
+    return;
   }
+
+  location.reload();
+}
+
 
   const displayCreatedAt = plant?.createdAt
     ? new Intl.DateTimeFormat('en-US', {
@@ -246,6 +249,7 @@
             Watered today
           </button>
 
+
           {#if isOwner}
             <!-- This works but there's no edit page created for plants
             <button
@@ -327,15 +331,16 @@
 
   <!-- Confirm: watered today -->
   <LogoutModal
-  open={showWaterConfirm}
-  title="Mark as watered?"
-  message="Do you want to mark this plant as watered today?"
-  confirmText="Yes"
-  cancelText="Cancel"
-  onConfirm={() => {
-    showWaterConfirm = false;
-    (document.getElementById('water-form')as HTMLFormElement).requestSubmit();
-  }}
-  onCancel={() => (showWaterConfirm = false)}
-/>
+    open={showWaterConfirm}
+    title="Mark as watered?"
+    message="Do you want to mark this plant as watered today?"
+    confirmText="Yes"
+    cancelText="Cancel"
+    onConfirm={async () => {
+      showWaterConfirm = false;
+      await wateredToday();
+    }}
+    onCancel={() => (showWaterConfirm = false)}
+  />
+
 </div>

--- a/src/routes/(app)/plants/[id]/+page.svelte
+++ b/src/routes/(app)/plants/[id]/+page.svelte
@@ -1,0 +1,246 @@
+<!-- src/routes/plants/[id]/+page.svelte -->
+<script lang="ts">
+  import LogoutModal from '$lib/components/LogoutModal.svelte';
+  import { page } from '$app/stores';
+
+  import {
+    ChevronLeft,
+    Leaf,
+    Info,
+    Sun,
+    Droplets,
+    Tag,
+    Calendar,
+    MapPin,
+    Pencil,
+    Trash2,
+    CheckCircle
+  } from 'lucide-svelte';
+
+  export let data;
+  const { user, plant, token } = data;
+
+  let showDeleteConfirm = false;
+  let showWaterConfirm = false;
+
+  // TEMP: everyone can see all plant actions for now
+  const isOwner = true;
+
+  // DELETE
+  async function deletePlant() {
+    const res = await fetch(`/api/plants/${plant.id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    if (!res.ok) {
+      alert('Delete failed. Please try again.');
+      return;
+    }
+
+    window.location.href = '/';
+  }
+
+  function goToEdit() {
+    window.location.href = `/plants/${plant.id}/edit`;
+  }
+
+  async function wateredToday() {
+    const res = await fetch(`/api/plants/${plant.id}/watered-today`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    if (!res.ok) {
+      alert("Couldn't save watering. Hook up the endpoint and try again.");
+      return;
+    }
+
+    alert('Saved: watered today ✅');
+  }
+
+  const displayCreatedAt = plant?.createdAt
+  ? new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(new Date(plant.createdAt))
+  : '—';
+
+  // If your API returns plantType relation later, this will work automatically
+  const plantTypeName = plant?.plantType?.name ?? 'Unknown';
+</script>
+
+<div class="flex flex-col h-full bg-stone-50 overflow-y-auto animate-in slide-in-from-right duration-300 pb-8 cursor-default">
+  <!-- HERO -->
+  <div class="relative h-72 md:h-96 w-full shrink-0">
+    <img
+      alt={plant?.name ?? 'Plant'}
+      src={plant?.image || 'https://picsum.photos/1200/800'}
+      class="w-full h-full object-cover"
+    />
+
+    <button
+      on:click={() => window.history.back()}
+      class="absolute top-8 left-6 z-20 bg-black/50 text-white p-3 rounded-full shadow-xl hover:bg-black/70 transition duration-300 ease-in-out cursor-pointer"
+      aria-label="Go back"
+    >
+      <ChevronLeft class="w-6 h-6" />
+    </button>
+
+    <div class="absolute inset-0 bg-linear-to-t from-stone-50 via-stone-50/50 to-transparent"></div>
+
+    <div class="absolute bottom-0 left-0 right-0 p-6 pt-10">
+      <span class="text-sm font-bold tracking-wider text-green-700 bg-white/70 backdrop-blur-sm px-4 py-1.5 rounded-full shadow-md inline-flex items-center gap-2">
+        <Leaf class="w-4 h-4" />
+        {plantTypeName}
+      </span>
+
+      <h1 class="text-4xl lg:text-5xl font-extrabold text-stone-900 mt-2 leading-tight drop-shadow-lg">
+        {plant?.name ?? 'Plant'}
+      </h1>
+
+      <p class="text-lg text-stone-700 font-medium italic mt-1">
+        {plant?.scientificName ?? ''}
+      </p>
+    </div>
+  </div>
+
+  <!-- BODY -->
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 p-6 max-w-7xl mx-auto w-full">
+    <!-- LEFT -->
+    <div class="lg:col-span-2 space-y-8">
+      <!-- About -->
+      <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200">
+        <h2 class="text-2xl font-bold text-stone-800 mb-4 flex items-center gap-3">
+          <Info class="w-6 h-6 text-green-600" /> About this Plant
+        </h2>
+
+        <p class="text-stone-600 text-base leading-relaxed whitespace-pre-wrap">
+          {plant?.description || 'No description available for this plant yet.'}
+        </p>
+      </div>
+
+      <!-- Key details -->
+      <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5">
+        <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
+          <Tag class="w-6 h-6 text-green-600" /> Key Plant Details
+        </h2>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 border-t border-stone-100 pt-5">
+          <div class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl">
+            <Tag class="w-5 h-5 text-green-600 shrink-0" />
+            <div>
+              <span class="text-xs font-semibold uppercase text-stone-500">Type</span>
+              <p class="font-medium text-stone-800">{plantTypeName}</p>
+            </div>
+          </div>
+
+          <div class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl">
+            <Calendar class="w-5 h-5 text-green-600 shrink-0" />
+            <div>
+              <span class="text-xs font-semibold uppercase text-stone-500">Added</span>
+              <p class="font-medium text-stone-800">{displayCreatedAt}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT -->
+    <div class="lg:col-span-1 space-y-8 sticky top-6 self-start">
+      <!-- Care card -->
+      <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5">
+        <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
+          <Leaf class="w-6 h-6 text-green-600" /> Care
+        </h2>
+
+        <div class="space-y-4">
+          <div class="flex justify-between items-center border-b border-stone-100 pb-3">
+            <div class="flex items-center space-x-3">
+              <Sun class="w-5 h-5 text-yellow-600 shrink-0" />
+              <span class="text-stone-700 font-medium">Sunlight</span>
+            </div>
+            <span class="font-bold text-lg text-yellow-700">{plant?.sunlightRequirement ?? 0}</span>
+          </div>
+
+          <div class="flex justify-between items-center">
+            <div class="flex items-center space-x-3">
+              <Droplets class="w-5 h-5 text-cyan-600 shrink-0" />
+              <span class="text-stone-700 font-medium">Water</span>
+            </div>
+            <span class="font-bold text-lg text-cyan-700">{plant?.waterNeeds ?? 0}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5">
+        <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
+          <CheckCircle class="w-6 h-6 text-green-600" /> Actions
+        </h2>
+
+        <div class="space-y-3 pt-1">
+          <button
+            on:click={() => (showWaterConfirm = true)}
+            class="w-full py-3 rounded-xl text-white font-extrabold text-lg shadow-xl transition flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 shadow-green-300/60 cursor-pointer"
+          >
+            <Droplets class="w-5 h-5" />
+            Watered today
+          </button>
+
+          {#if isOwner}
+            <button
+              on:click={goToEdit}
+              class="w-full py-3 rounded-xl font-extrabold text-lg shadow-md transition flex items-center justify-center gap-2 bg-stone-800 hover:bg-stone-900 text-white cursor-pointer"
+            >
+              <Pencil class="w-5 h-5" />
+              Edit
+            </button>
+
+            <button
+              on:click={() => (showDeleteConfirm = true)}
+              class="w-full py-3 rounded-xl font-extrabold text-lg shadow-md transition flex items-center justify-center gap-2 bg-red-700 hover:bg-red-800 text-white cursor-pointer"
+            >
+              <Trash2 class="w-5 h-5" />
+              Delete
+            </button>
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirm: delete -->
+  <LogoutModal
+    open={showDeleteConfirm}
+    title="Delete plant?"
+    message="Are you sure you want to delete this plant? This can't be undone."
+    confirmText="Delete"
+    cancelText="Cancel"
+    onConfirm={() => {
+      showDeleteConfirm = false;
+      deletePlant();
+    }}
+    onCancel={() => (showDeleteConfirm = false)}
+  />
+
+  <!-- Confirm: watered today -->
+  <LogoutModal
+    open={showWaterConfirm}
+    title="Mark as watered?"
+    message="Do you want to mark this plant as watered today?"
+    confirmText="Yes"
+    cancelText="Cancel"
+    onConfirm={() => {
+      showWaterConfirm = false;
+      wateredToday();
+    }}
+    onCancel={() => (showWaterConfirm = false)}
+  />
+</div>

--- a/src/routes/(app)/plants/[id]/+page.svelte
+++ b/src/routes/(app)/plants/[id]/+page.svelte
@@ -17,8 +17,22 @@
     CheckCircle
   } from 'lucide-svelte';
 
+  import { onMount } from 'svelte';
+  let showDeletedToast = false;
+
+  onMount(() => {
+    if ($page.url.searchParams.get('deleted') === '1') {
+      showDeletedToast = true;
+
+      // auto-hide after 3s
+      setTimeout(() => {
+        showDeletedToast = false;
+      }, 3000);
+    }
+  });
+
   export let data;
-  const { user, plant, token } = data;
+  const { user, plant, ownerHistory, token } = data;
 
   let showDeleteConfirm = false;
   let showWaterConfirm = false;
@@ -56,27 +70,58 @@
     });
 
     if (!res.ok) {
-      alert("Couldn't save watering. Hook up the endpoint and try again.");
+      alert("Couldn't save watering. Please try again.");
       return;
     }
 
-    alert('Saved: watered today ✅');
+    // Refresh page data so latestPlanted.waterLevel becomes 0 in the UI
+    location.reload();
   }
 
   const displayCreatedAt = plant?.createdAt
-  ? new Intl.DateTimeFormat('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    }).format(new Date(plant.createdAt))
-  : '—';
+    ? new Intl.DateTimeFormat('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      }).format(new Date(plant.createdAt))
+    : '—';
 
   // If your API returns plantType relation later, this will work automatically
   const plantTypeName = plant?.plantType?.name ?? 'Unknown';
+
+  // Change background color based on the sunlightLevel & waterLevel
+  type Level = 0 | 1 | 2;
+
+  const toLevel = (v: unknown): Level => {
+    const n = Number(v);
+    return n === 0 || n === 1 || n === 2 ? n : 0;
+  };
+
+  const levelUi = (level: Level) => {
+    if (level === 0) {
+      return { text: 'Healthy', classes: 'bg-green-100 text-green-800 ring-1 ring-green-200' };
+    }
+    if (level === 1) {
+      return { text: 'Needs care', classes: 'bg-yellow-100 text-yellow-800 ring-1 ring-yellow-200' };
+    }
+    return { text: 'Critical', classes: 'bg-red-100 text-red-800 ring-1 ring-red-200' };
+  };
+
+  // Use your actual DB columns here if available on this page
+  const latestPlanted = plant?.plantedPlants?.[0];
+
+  const sunlightLevel = toLevel(latestPlanted?.sunlightLevel ?? 0);
+  const waterLevel = toLevel(latestPlanted?.waterLevel ?? 0);
 </script>
 
 <div class="flex flex-col h-full bg-stone-50 overflow-y-auto animate-in slide-in-from-right duration-300 pb-8 cursor-default">
+  {#if showDeletedToast}
+    <div class="fixed top-6 right-6 z-50 bg-green-600 text-white font-bold px-6 py-3 rounded-xl shadow-xl animate-in slide-in-from-right duration-300">
+      🌱 Your plant has been deleted
+    </div>
+  {/if}
+
   <!-- HERO -->
   <div class="relative h-72 md:h-96 w-full shrink-0">
     <img
@@ -127,7 +172,7 @@
       </div>
 
       <!-- Key details -->
-      <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5">
+      <div class="bg-white rounded-3xl p-8 md:p-10 shadow-xl border border-stone-200 space-y-6">
         <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
           <Tag class="w-6 h-6 text-green-600" /> Key Plant Details
         </h2>
@@ -144,7 +189,7 @@
           <div class="flex items-center space-x-3 p-3 bg-stone-50 rounded-xl">
             <Calendar class="w-5 h-5 text-green-600 shrink-0" />
             <div>
-              <span class="text-xs font-semibold uppercase text-stone-500">Added</span>
+              <span class="text-xs font-semibold uppercase text-stone-500">Planted</span>
               <p class="font-medium text-stone-800">{displayCreatedAt}</p>
             </div>
           </div>
@@ -166,7 +211,10 @@
               <Sun class="w-5 h-5 text-yellow-600 shrink-0" />
               <span class="text-stone-700 font-medium">Sunlight</span>
             </div>
-            <span class="font-bold text-lg text-yellow-700">{plant?.sunlightRequirement ?? 0}</span>
+            <span class={`inline-flex items-center px-3 py-1 rounded-full text-sm font-extrabold shadow-sm ${levelUi(sunlightLevel).classes}`}>
+              {levelUi(sunlightLevel).text}
+              <span class="ml-2 text-xs font-bold opacity-70"></span>
+            </span>
           </div>
 
           <div class="flex justify-between items-center">
@@ -174,7 +222,10 @@
               <Droplets class="w-5 h-5 text-cyan-600 shrink-0" />
               <span class="text-stone-700 font-medium">Water</span>
             </div>
-            <span class="font-bold text-lg text-cyan-700">{plant?.waterNeeds ?? 0}</span>
+            <span class={`inline-flex items-center px-3 py-1 rounded-full text-sm font-extrabold shadow-sm ${levelUi(waterLevel).classes}`}>
+              {levelUi(waterLevel).text}
+              <span class="ml-2 text-xs font-bold opacity-70"></span>
+            </span>
           </div>
         </div>
       </div>
@@ -186,6 +237,7 @@
         </h2>
 
         <div class="space-y-3 pt-1">
+          <form id="water-form" method="POST" action="?/wateredToday" class="hidden"></form>
           <button
             on:click={() => (showWaterConfirm = true)}
             class="w-full py-3 rounded-xl text-white font-extrabold text-lg shadow-xl transition flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 shadow-green-300/60 cursor-pointer"
@@ -195,6 +247,7 @@
           </button>
 
           {#if isOwner}
+            <!-- This works but there's no edit page created for plants
             <button
               on:click={goToEdit}
               class="w-full py-3 rounded-xl font-extrabold text-lg shadow-md transition flex items-center justify-center gap-2 bg-stone-800 hover:bg-stone-900 text-white cursor-pointer"
@@ -202,6 +255,9 @@
               <Pencil class="w-5 h-5" />
               Edit
             </button>
+            -->
+
+            <form id="delete-form" method="POST" action="?/delete" class="hidden"></form>
 
             <button
               on:click={() => (showDeleteConfirm = true)}
@@ -216,6 +272,45 @@
     </div>
   </div>
 
+  <!-- Owner history -->
+  <div class="bg-white rounded-3xl p-6 md:p-8 shadow-xl border border-stone-200 space-y-5">
+    <h2 class="text-2xl font-bold text-stone-800 flex items-center gap-3">
+      <MapPin class="w-6 h-6 text-green-600" /> Owner history
+    </h2>
+
+    {#if ownerHistory?.length}
+      <div class="space-y-3">
+        {#each ownerHistory as h}
+          <div class="p-4 bg-stone-50 rounded-2xl border border-stone-100">
+            <div class="flex items-center justify-between gap-3">
+              <p class="font-bold text-stone-800 truncate">
+                {h.owner?.userName ?? `User #${h.ownerId}`}
+              </p>
+
+              {#if h.isActive}
+                <span class="text-xs font-extrabold px-2.5 py-1 rounded-full bg-green-100 text-green-800 ring-1 ring-green-200">
+                  Current
+                </span>
+              {/if}
+            </div>
+
+            <p class="text-xs text-stone-500 mt-1">
+              {new Date(h.createdAt).toLocaleString()}
+            </p>
+
+            {#if h.notes}
+              <p class="text-sm text-stone-700 mt-2 whitespace-pre-wrap">
+                {h.notes}
+              </p>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <p class="text-stone-600">No owner history yet.</p>
+    {/if}
+  </div>
+
   <!-- Confirm: delete -->
   <LogoutModal
     open={showDeleteConfirm}
@@ -225,22 +320,22 @@
     cancelText="Cancel"
     onConfirm={() => {
       showDeleteConfirm = false;
-      deletePlant();
+      (document.getElementById('delete-form') as HTMLFormElement).requestSubmit();
     }}
     onCancel={() => (showDeleteConfirm = false)}
   />
 
   <!-- Confirm: watered today -->
   <LogoutModal
-    open={showWaterConfirm}
-    title="Mark as watered?"
-    message="Do you want to mark this plant as watered today?"
-    confirmText="Yes"
-    cancelText="Cancel"
-    onConfirm={() => {
-      showWaterConfirm = false;
-      wateredToday();
-    }}
-    onCancel={() => (showWaterConfirm = false)}
-  />
+  open={showWaterConfirm}
+  title="Mark as watered?"
+  message="Do you want to mark this plant as watered today?"
+  confirmText="Yes"
+  cancelText="Cancel"
+  onConfirm={() => {
+    showWaterConfirm = false;
+    (document.getElementById('water-form')as HTMLFormElement).requestSubmit();
+  }}
+  onCancel={() => (showWaterConfirm = false)}
+/>
 </div>

--- a/src/routes/(app)/plants/[id]/watered-today/+server.ts
+++ b/src/routes/(app)/plants/[id]/watered-today/+server.ts
@@ -1,0 +1,25 @@
+import { PUBLIC_API_URL } from '$env/static/public';
+import { error } from '@sveltejs/kit';
+
+export async function POST({ params, fetch, cookies }) {
+  const token = cookies.get('token');
+  if (!token) throw error(401, 'Not authenticated');
+
+  const res = await fetch(`${PUBLIC_API_URL}/plants/${params.id}/watered-today`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  // If your backend ever returns 204, pass it through cleanly
+  if (res.status === 204) {
+    return new Response(null, { status: 204 });
+  }
+
+  const body = await res.text(); // forward whatever backend returns
+  return new Response(body, {
+    status: res.status,
+    headers: { 'Content-Type': res.headers.get('content-type') ?? 'application/json' }
+  });
+}


### PR DESCRIPTION
### What’s included
- Added plant overview page (`/plants`) with search and create flow
- Added detailed plant page (`/plants/:id`) showing:
  - plant type
  - scientific name
  - description
  - planted date
  - water & sunlight levels
  - owner history
- Implemented homepage garden map showing plant locations based on stored coordinates
- Made plant icons on the map clickable to open plant detail pages
- Added visual plant status indicators (healthy / needs care / critical)
- Added “Watered today” interaction that updates plant water level via API
- Improved UI feedback (confirmation modals, status updates, toast messages)

### Related tickets
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/93
- https://github.com/Where-s-Serj-TSTWR-Team-5/frontend/issues/1
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/11
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/14
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/12
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/16
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/28
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/29
- https://github.com/Where-s-Serj-TSTWR-Team-5/backend/issues/31

### Notes
- Ownership transfer is intentionally not implemented (out of scope)
- Plant-type icons are considered a could-have and not included
- Backend integration via API Gateway is fully wired
- Edit plants button has been hidden, the backend is working but there's no edit page created for plants